### PR TITLE
Fix a couple of typos in code.md

### DIFF
--- a/kagi/src/features/code.md
+++ b/kagi/src/features/code.md
@@ -1,8 +1,8 @@
-# Code Seaching
+# Code Searching
 
 Kagi supports developers with code samples in response to search results. 
 
-For example, consdier searching for <i>write!<i>
+For example, consider searching for <i>write!<i>
 
 <img src="media/initial_write_search.PNG" alt="Write Search No Filter">
 

--- a/kagi/src/misc/contributors.md
+++ b/kagi/src/misc/contributors.md
@@ -15,6 +15,7 @@ Thank you!
 - Liam 
 - Vladimir Prelovac ([vprelovac](https://github.com/vprelovac))
 - Lukas Winkler ([Findus23](https://github.com/Findus23))
+- Daniel Martín ([danielmartin](https://github.com/danielmartin))
 
 If you feel you're missing from this list, feel free to add yourself in a pull request.
 


### PR DESCRIPTION
Just fixed a couple of typos in the documentation.