### PR TITLE
Fix contribute links

### DIFF
--- a/kagi/src/support-and-community/index.md
+++ b/kagi/src/support-and-community/index.md
@@ -1,3 +1,3 @@
 # Support and Community
 
-Get assistance, help shape the future of Kagi and maybe even [contribute!](./support-and-community/contribute.md)
+Get assistance, help shape the future of Kagi and maybe even [contribute!](./contribute.md)

--- a/orion/src/support-and-community/index.md
+++ b/orion/src/support-and-community/index.md
@@ -1,6 +1,6 @@
 # Support & Community
 
-Get assistance, help shape the future of Orion and maybe even [contribute!](./support-and-community/contribute.md)
+Get assistance, help shape the future of Orion and maybe even [contribute!](./contribute.md)
 
 ## Roadmap
 


### PR DESCRIPTION
Looks like the structure may have changed at some point but these links weren't updated.

Live pages with the broken links:

- https://help.kagi.com/kagi/support-and-community/index.html
- https://help.kagi.com/orion/support-and-community/index.html