### PR TITLE
fix: typo in roadmap and feedback page

### DIFF
--- a/kagi/src/support-and-community/roadmap_feedback.md
+++ b/kagi/src/support-and-community/roadmap_feedback.md
@@ -7,7 +7,7 @@ Check out our [roadmap](https://kagifeedback.org/roadmap).
 
 ## Release notes & RSS
 
-HTML version of release notes is availableat:
+HTML version of release notes is available at:
 [kagi.com/changelog](https://kagi.com/changelog)
 
 

--- a/kagi/src/support-and-community/roadmap_feedback.md
+++ b/kagi/src/support-and-community/roadmap_feedback.md
@@ -8,7 +8,7 @@ Check out our [roadmap](https://kagifeedback.org/roadmap).
 ## Release notes & RSS
 
 HTML version of release notes is availableat:
-[kagi.com/changelogl](https://kagi.com/changelog)
+[kagi.com/changelog](https://kagi.com/changelog)
 
 
 RSS feed for release notes is available at:


### PR DESCRIPTION
One character fix for a typo in the work 'changelog'. The underlying link is correct.

- Replace 'changelogl' with 'changelog'