### PR TITLE
Add new ways to disable animations for GNOME 43 & GNOME 44

### DIFF
--- a/kagi/src/features/turning-off-animations.md
+++ b/kagi/src/features/turning-off-animations.md
@@ -10,6 +10,7 @@ Here is where to find the settings for each OS:
 - In **Windows 10**: Settings > Ease of Access > Display > Show animations in Windows.
 - In **Windows 7**: Control Panel > Ease of Access > Make the computer easier to see > Turn off all unnecessary animations (when possible).
 - In **Android 9+**: Settings > Accessibility > Remove animations.
-- In **GTK/GNOME 43+**: Settings > Accessibility > Enable Animations (turn it off)
+- In **GNOME 44**: Settings > Accessibility > Seeing > Reduce Animation (turn it off)
+- In **GNOME 43**: Settings > Accessibility > Enable Animations (turn it off)
 - In **GNOME 42 and Before**: GNOME Tweaks > General tab (or Appearance, depending on version) > Animations is turned off.
 - In **Plasma/KDE**: System Settings > Workspace Behavior -> General Behavior > "Animation speed" is set all the way to the right to "Instant".

--- a/kagi/src/features/turning-off-animations.md
+++ b/kagi/src/features/turning-off-animations.md
@@ -10,5 +10,6 @@ Here is where to find the settings for each OS:
 - In **Windows 10**: Settings > Ease of Access > Display > Show animations in Windows.
 - In **Windows 7**: Control Panel > Ease of Access > Make the computer easier to see > Turn off all unnecessary animations (when possible).
 - In **Android 9+**: Settings > Accessibility > Remove animations.
-- In **GTK/GNOME**: GNOME Tweaks > General tab (or Appearance, depending on version) > Animations is turned off.
+- In **GTK/GNOME 43+**: Settings > Accessibility > Enable Animations (turn it off)
+- In **GNOME 42 and Before**: GNOME Tweaks > General tab (or Appearance, depending on version) > Animations is turned off.
 - In **Plasma/KDE**: System Settings > Workspace Behavior -> General Behavior > "Animation speed" is set all the way to the right to "Instant".


### PR DESCRIPTION
The GNOME Tweaks program removed this option some time in 2022 as it is now available in the default Control Centre program for GNOME: https://gitlab.gnome.org/GNOME/gnome-tweaks/-/issues/383