### PR TITLE
Explain how to enter the private session token in the Firefox extension

### DIFF
--- a/kagi/src/getting-started/setting-default.md
+++ b/kagi/src/getting-started/setting-default.md
@@ -30,6 +30,7 @@ Extension download links:
 - [Chromium-based browsers](https://chrome.google.com/webstore/detail/cdglnehniifkbagbbombnjghhcihifij) (Chrome, Edge, Brave, Opera, Vivaldi...)
 - [Firefox-based browsers](https://addons.mozilla.org/en-US/firefox/addon/kagi-search-for-firefox/)
   - If you use Firefox on Android, check out [this guide](https://blog.mozilla.org/addons/2020/09/29/expanded-extension-support-in-firefox-for-android-nightly/). Android doesn't set Kagi as the default search engine, but it allows search in private mode to work normally.
+  - After installing the extension, go to the extension settings (click the puzzle piece in the top right corner of the browser window) for Kagi and enter your [private session token URL](#private_session) to be logged in automatically even when cookies have been deleted.
 - [Safari for macOS](https://apps.apple.com/app/kagi-search-for-safari/id1622835804)
 - [Safari for iOS and iPadOS](https://apps.apple.com/app/kagi-search-for-safari/id1607766153)
 - The [xSearch](https://apps.apple.com/us/app/xsearch-for-safari/id1579902068) and [HyperWeb](https://apps.apple.com/us/app/hyperweb/id1581824571) extensions for Safari also support Kagi


### PR DESCRIPTION
In my opinion, the extension settings are rather hidden in Firefox, so I think it would make sense to tell people that they exist, and how to find them.