### PR TITLE
fix file extention

### DIFF
--- a/kagi/src/settings/appearance.md
+++ b/kagi/src/settings/appearance.md
@@ -18,7 +18,7 @@ These settings control various visual options.
 
 In some cases you may want to apply custom CSS, a common example is removing the summary boxes at the top of search results.
 
-![The Three Boxes](media/threeboxes.PNG)
+![The Three Boxes](media/threeboxes.png)
 
 This can be accomplished from within the [Custom CSS](https://kagi.com/settings?p=custom_css) editor.
 


### PR DESCRIPTION
The image `threeboxes.png` fails to load because the link points towards `threeboxes.PNG`, which doesn't exist.

See here [https://help.kagi.com/kagi/settings/appearance.html](https://help.kagi.com/kagi/settings/appearance.html) (bottom of page):

![image](https://github.com/kagisearch/kagi-docs/assets/41589344/83f62911-f359-47ab-b4a9-889445095bc2)

The image fails to load with every browser I tried. Interestingly, however, when serving mdbook locally, the image is loaded successfully using either `*.png` or `*.PNG`.
