### PR TITLE
Add Dockerfile and instructions

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+# Ignore .git, .gitignore, .gitattribute etc files when building the Docker image
+**/.git*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM rust:latest
+
+RUN cargo install mdbook
+
+# We don't `COPY` the data into the image, because both for `build` and `serve`
+# it's useful to mount the data from the host at runtime.
+
+# We don't predefine a `WORKDIR` for flexibility to use the kagi or orion Knowledgebase Maps.
+
+VOLUME /kagi-docs
+
+EXPOSE 3000
+
+ENTRYPOINT ["mdbook"]
+
+# This serves on 0.0.0.0:3000 by default, suitable for running in a standard Docker network.
+# This way the server is reachable from the host via `localhost:3000` when you start the container with `docker run -p 127.0.0.1:3000:3000 ...`.
+#
+# Alternatively, when you want to run the container in the host network, you might not want to expose the server to other hosts.
+# Then you run with `docker run ... --network host <image> serve -n localhost`.
+CMD ["serve", "-n", "0.0.0.0"]

--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ This repository contains open-source documentation for products made by Kagi Inc
 
 This repo serves documentation for multiple products developed by Kagi.
 
-
 Product | Documentation         | Repo Directory
 --------|-----------------------|----------------
 [Kagi Search](https://kagi.com) | https://help.kagi.com/kagi | [kagi](https://github.com/kagisearch/kagi-docs/tree/main/kagi)
@@ -112,7 +111,6 @@ details we need to help accept your changes.
 All documentation is written to be hosted with the open-source
 [mdBook](https://rust-lang.github.io/mdBook/) documentation utility.
 
-
 Each directory in the [Knowledgebase Map](#knowledgebase-map) is built as its
 own book, configured for that products own criteria, look, and feel.
 
@@ -121,10 +119,20 @@ To get started:
 1. Install [mdBook](https://rust-lang.github.io/mdBook/guide/installation.html)
 2. Navigate to the book you wish to build in the [Knowledgebase Map](#knowledgebase-map)
 3. Run `mdbook build` in that directory to compile the book to a `book/`
-   directory with the rendered contents
+   directory with the rendered contents. You can open `book/index.html` to start browsing.
 
 You can also run `mdbook serve` and open [http://localhost:3000](http://localhost:3000)
 to view the documentation in your browser. mdBook will watch your files and automatically
 rebuild & refresh the page when the book's files are updated.
 
 See each book's `book.toml` for configuration options we have applied.
+
+### With Docker
+
+If you don't have and don't want to install Rust on your local machine, you can use Docker instead. The command examples assume you're in the root of the Git repository.
+
+1. Build the image `docker build -t kagi-docs .`
+2. Run the container to build or serve:
+   - Build example: `docker run --rm -v /path/to/kagi-docs:/kagi-docs --workdir /kagi-docs/kagi kagi-docs build`.
+   - Serve example: `docker run -it --rm -v /path/to/kagi-docs:/kagi-docs --workdir /kagi-docs/kagi -p 127.0.0.1:3000:3000 kagi-docs`.
+     - If mdBooks doesn't stop on Ctrl+C, you can detach with Ctrl+P Ctrl+Q and then run `docker stop <container_name>`


### PR DESCRIPTION
Hello :wave: , I was working on https://github.com/kagisearch/kagi-docs/pull/58 and used Docker to run mdBook. They don't provide an official image yet, so I added a Dockerfile to the repo. Maybe it's useful for others as well?

Feel free to decline the PR if you think it's not very useful, no hurt feelings :slightly_smiling_face: 

Also let me know if you prefer not to have the long comments in the Dockerfile.