### PR TITLE
docs: add kagigo API client lib

### DIFF
--- a/kagi/src/api/overview.md
+++ b/kagi/src/api/overview.md
@@ -8,6 +8,10 @@ results & more.
 - [Search API](search.md)
 - [Universal Summarizer API](summarizer.md)
 
+## Client Libraries
+
+- [kagigo for Go](https://github.com/httpjamesm/kagigo)
+
 ## Beta Status
 
 **The API is currently in a "v0" beta status.** Changes will be ongoing,


### PR DESCRIPTION
* Adds my Go client library for the FastGPT and Universal Summarizer APIs