### PR TITLE
Add anchor tags suffix to section headers to fix Vitepress behavior

### DIFF
--- a/docs/orion/features/low-power-mode.md
+++ b/docs/orion/features/low-power-mode.md
@@ -9,7 +9,7 @@ Inspired by the same feature on iPhone, Low Power Mode reduces Orion's power con
 - [iPadOS Low Power Mode](#ipados)
 
 <a name="macos"></a>
-## macOS Low Power Mode
+## macOS Low Power Mode {#macos}
 
 You can enable Low Power Mode by clicking the **Tools** menu and then clicking **Low Power Mode...**.
 
@@ -22,7 +22,7 @@ You can then click the **Enable** button in the window that appears.
 You can disable Low Power Mode using the same menu option.
 
 <a name="ios"></a>
-## iOS Low Power Mode
+## iOS Low Power Mode {#ios}
 
 You can enable Low Power Mode in Orion's Settings.
 
@@ -38,7 +38,7 @@ You can enable Low Power Mode in Orion's Settings.
 You can disable Low Power Mode from the same place.
 
 <a name="ipados"></a>
-## iPadOS Low Power Mode
+## iPadOS Low Power Mode {#ipados}
 
 You can enable Low Power Mode in Orion's Settings.
 

--- a/docs/orion/features/password-management.md
+++ b/docs/orion/features/password-management.md
@@ -10,7 +10,7 @@
 - [1Password & Orion](#1password)
 
 <a name="password_storage_sync"></a>
-## Password Storage & Sync
+## Password Storage & Sync {#password_storage_sync}
 
 Many users of Safari on Apple devices use iCloud Keychain to automatically sync Safari data, including website passwords, across devices.
 
@@ -19,7 +19,7 @@ Third-party web browsers, like Orion, cannot sync with the Keychain used by Safa
 If you want to use your Safari passwords in Orion, you will need to import the passwords into Orion on macOS. Then, you can use the passwords in Orion on all Apple devices through Orion's own Keychain sync.
 
 <a name="import_safari_passwords"></a>
-## Importing Safari Passwords into Orion on macOS
+## Importing Safari Passwords into Orion on macOS {#import_safari_passwords}
 
 Orion on macOS can import your passwords from Safari 15+ on macOS. These versions of Safari ship with macOS 12 (Monterey) and macOS 13 (Ventura). They are also available on macOS 11 (Big Sur) through the [Safari Technology Preview](https://developer.apple.com/safari/download/).
 
@@ -34,12 +34,12 @@ Once you have Safari 15+, follow these steps in Orion:
 <img src="./media/macos_safari_import.png" width="300" alt="Safari Import"><br />
 
 <a name="syncing_passwords"></a>
-## Syncing Passwords in Orion
+## Syncing Passwords in Orion {#syncing_passwords}
 
 To sync Orion passwords across devices, perform these steps <u>on each device</u>.
 
 <a name="syncing_passwords_macos"></a>
-### macOS
+### macOS {#syncing_passwords_macos}
 
 1. Click the Apple menu (), click **System Preferences**, and click **Apple ID**.
    - If you're using macOS 3.14 (Mojave), you don't need to click Apple ID.
@@ -53,7 +53,7 @@ To sync Orion passwords across devices, perform these steps <u>on each device</u
 <img src="./media/macos_icloud_keychain.png" width="500" alt="Open macOS System Preferences"><br />
 
 <a name="syncing_passwords_ios"></a>
-### iOS
+### iOS {#syncing_passwords_ios}
 
 1. Open the Settings app for your device.
 2. Tap your name at the top of Settings.
@@ -65,7 +65,7 @@ To sync Orion passwords across devices, perform these steps <u>on each device</u
 <img src="./media/ios_keychain.png" width="300" alt="iOS iCloud Keychain Settings"><br />
 
 <a name="syncing_passwords_ipados"></a>
-### iPadOS
+### iPadOS {#syncing_passwords_ipados}
 
 1. Open the Settings app for your device.
 2. Tap your name at the top left corner of Settings.
@@ -80,7 +80,7 @@ To sync Orion passwords across devices, perform these steps <u>on each device</u
 <img src="./media/ipados_keychain.png" width="500" alt="iPadOS iCloud Keychain Settings"><br />
 
 <a name="1password"></a>
-## 1Password & Orion
+## 1Password & Orion {#1password}
 
 1Password has not yet added support for Orion. Because of this, the 1Password browser extension does not function properly in Orion.
 

--- a/docs/orion/features/quick-searches.md
+++ b/docs/orion/features/quick-searches.md
@@ -7,7 +7,7 @@
 - [iPadOS Quick Searches](#iPadOS)
 
 <a name="macOS"></a>
-## macOS Quick Searches
+## macOS Quick Searches {#macOS}
 
 You can search specific websites directly in Orion with Quick Search bookmarks that use invocation keywords.
 
@@ -42,7 +42,7 @@ You can repeat this process with the search results page for any website to add 
 You can also edit any existing search results bookmark to make it into a Quick Search bookmark.
 
 <a name="iOS"></a>
-## iOS Quick Searches
+## iOS Quick Searches {#iOS}
 
 **Quick Searches will be coming to iOS soon and these instructions explain how they will work.**
 
@@ -74,7 +74,7 @@ You can repeat this process with the search results page for any website to add 
 You can also edit any existing search results bookmark to make it into a Quick Search bookmark.
 
 <a name="iPadOS"></a>
-## iPadOS Quick Searches
+## iPadOS Quick Searches {#iPadOS}
 
 **Quick Searches will be coming to iPadOS soon and these instructions explain how they will work.**
 

--- a/docs/orion/features/reader-mode.md
+++ b/docs/orion/features/reader-mode.md
@@ -11,7 +11,7 @@ Sometimes you just want to read the article on a website, not wade through ads, 
 - [iPadOS Reader Mode](#ipados_reader_mode)
 
 <a name="macos_reader_mode"></a>
-## macOS Reader Mode
+## macOS Reader Mode {#macos_reader_mode}
 
 You can enable Reader Mode in three different ways while viewing a webpage.
 
@@ -45,7 +45,7 @@ You can view and manage the Reader Mode settings for all websites in Orion's Pre
   <img src="./media/macos_reader_mode_preferences.png" width="500" alt="macOS Reader Mode Preferences"><br />
 
 <a name="ios_reader_mode"></a>
-## iOS Reader Mode
+## iOS Reader Mode {#ios_reader_mode}
 
 You can enable Reader Mode by tapping on the icon for the current website in the address bar and then tapping Reader Mode.
 
@@ -73,7 +73,7 @@ You can view and manage the Reader Mode settings for all websites in Orion's Set
  <img src="./media/ios_reader_mode_settings_detail.png" width="300" alt="iOS Reader Mode Settings Detail"><br />
 
 <a name="ipados_reader_mode"></a>
-## iPadOS Reader Mode
+## iPadOS Reader Mode {#ipados_reader_mode}
 
 You can enable Reader Mode by tapping on the icon for the current website in the address bar and then tapping Reader Mode.
 

--- a/docs/orion/features/syncing-data.md
+++ b/docs/orion/features/syncing-data.md
@@ -9,9 +9,10 @@ To sync Orion tabs, bookmarks, and reading lists across devices, perform these s
 - [macOS](#syncing_macos)
 - [iOS](#syncing_ios)
 - [iPadOS](#syncing_ipados)
+- [Troubleshooting](#troubleshooting)
 
 <a name="syncing_macos"></a>
-## macOS
+## macOS  {#syncing_macos}
 
 1. In Orion, use the **Orion** menu to open Preferences.
 
@@ -22,7 +23,7 @@ To sync Orion tabs, bookmarks, and reading lists across devices, perform these s
 <img src="./media/macos_orion_sync_tab.png" width="500" alt="Orion Sync Tab"><br />
 
 <a name="syncing_ios"></a>
-## iOS
+## iOS  {#syncing_ios}
 
 1. Open the Orion app.
 2. Tap the three-dot menu (•••) in the lower-right corner of the screen.
@@ -35,7 +36,7 @@ To sync Orion tabs, bookmarks, and reading lists across devices, perform these s
 <img src="./media/ios_sync_settings.png" width="300" alt="iOS iCloud Settings"><br />
 
 <a name="syncing_ipados"></a>
-## iPadOS
+## iPadOS {#syncing_ipados}
 
 1. Open the Orion app.
 2. Tap the three-dot menu (•••) in the upper-right corner of the screen.
@@ -47,7 +48,8 @@ To sync Orion tabs, bookmarks, and reading lists across devices, perform these s
 
 <img src="./media/ipados_sync_settings.png" width="500" alt="iPadOS Orion Sync Settings"><br />
 
-## Troubleshooting
+<a name="troubleshooting"></a>
+## Troubleshooting {#troubleshooting}
 
 If you have problems syncing between devices try the following in order:
 

--- a/docs/orion/features/tab-groups.md
+++ b/docs/orion/features/tab-groups.md
@@ -11,7 +11,7 @@ In Orion, Tab Groups are also called Named Windows. You can [sync](syncing-data.
 - [iPadOS Tab Groups](#ipados_tab_groups)
 
 <a name="macos_tab_groups"></a>
-## macOS Tab Groups
+## macOS Tab Groups {#macos_tab_groups}
 
 Simply use the **Rename** command in the windows menu to give the current window a name, such as "Work".
 
@@ -22,7 +22,7 @@ Simply use the **Rename** command in the windows menu to give the current window
 The Tab Group will now sync in Orion across all of your devices where [syncing](syncing-data.md) is enabled.
 
 <a name="ios_tab_groups"></a>
-## iOS Tab Groups
+## iOS Tab Groups {#ios_tab_groups}
 
 1. Tap the icon that looks like two squares at the bottom on the screen.
 
@@ -45,7 +45,7 @@ The Tab Group will now sync in Orion across all of your devices where [syncing](
 The Tab Group will now sync in Orion across all of your devices where [syncing](syncing-data.md) is enabled.
 
 <a name="ipados_tab_groups"></a>
-## iPadOS Tab Groups
+## iPadOS Tab Groups {#ipados_tab_groups}
 
 1. Tap the icon that looks like two squares at the top right of the screen.
 

--- a/docs/orion/features/vertical-tabs.md
+++ b/docs/orion/features/vertical-tabs.md
@@ -11,7 +11,7 @@ If you love to have your browser tabs on the side, Orion has you covered with na
 - [iPadOS Vertical Tabs](#ipados_tab_styles)
 
 <a name="macos_vertical_tabs"></a>
-## macOS Vertical Tabs
+## macOS Vertical Tabs {#macos_vertical_tabs}
 
 You can enable vertical tabs by clicking the **View** menu and choosing **Show Vertical Tabs Sidebar**.
 
@@ -20,7 +20,7 @@ You can enable vertical tabs by clicking the **View** menu and choosing **Show V
 You can disable vertical tabs by going under the same **View** menu and choosing **Hide Vertical Tabs Sidebar**.
 
 <a name="ios_tab_styles"></a>
-## iOS Tab Styles
+## iOS Tab Styles {#ios_tab_styles}
 
 You can switch between **Sidebar** or **Grid** tab styles in Orion's settings.
 
@@ -38,7 +38,7 @@ Then, choose between **Sidebar** or **Grid**.
 <img src="./media/ios_tabs_settings_detail.png" width="300" alt="iOS Tabs Settings Detail"><br />
 
 <a name="ipados_tab_styles"></a>
-## iPadOS Tab Styles
+## iPadOS Tab Styles {#ipados_tab_styles}
 
 You can switch between **Sidebar** or **Grid** tab styles in Orion's settings.
 

--- a/docs/orion/features/website-settings.md
+++ b/docs/orion/features/website-settings.md
@@ -7,7 +7,7 @@
 - [iPadOS Website Settings](#iPadOS)
 
 <a name="macOS"></a>
-## macOS Website Settings
+## macOS Website Settings {#macOS}
 
 You can click the gear icon at the top of an Orion window to access the Website Settings for the current webpage.
 
@@ -31,7 +31,7 @@ You can control a number of settings related to the current website:
  - Control whether the website is set to **Allow** access, **Deny** access, or **Ask** for access to your **Camera**, **Microphone**, **Screen Sharing**, **Location**, and **Notifications**
 
 <a name="iOS"></a>
-## iOS Website Settings
+## iOS Website Settings {#iOS}
 
 You can tap the icon for a website in Orion's address bar to access the Website Settings for the current web page.
 
@@ -47,7 +47,7 @@ You can control several settings related to the current website:
 <img src="./media/ios_website_settings_detail.png" width="300" alt="iOS Website Settings Detail"><br />
 
 <a name="iPadOS"></a>
-## iPadOS Website Settings
+## iPadOS Website Settings {#iPadOS}
 
 You can tap the icon for a website in Orion's address bar to access the Website Settings for the current web page.
 


### PR DESCRIPTION
Updated most Orion Features pages to add the anchor tags suffix to section headers in order to accommodate Vitepress behavior when using table of contents.