### PR TITLE
Docs reorg 2

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -71,17 +71,9 @@ function sidebarKagi() {
                     link: '/kagi/company/',
                     items: [
                         { text: 'About', link: '/kagi/company/' },
-                        { text: 'Product', link: '/kagi/company/products' },
+                        { text: 'Products', link: '/kagi/company/products' },
                         { text: 'History', link: '/kagi/company/history' },
-                        {
-                            text: 'Name', link: '/kagi/company/meaning',
-                            collapsed: true,
-                            items: [
-                                { text: 'Mascot', link: '/kagi/company/mascot' },
-                                { text: 'Logo', link: '/kagi/company/logo' },
-                            ]
-                        },
-                        { text: 'Assets', link: '/kagi/company/assets' },
+                         { text: 'Assets', link: '/kagi/company/assets' },
                         {
                             text: 'Jobs', link: '/kagi/company/hiring-kagi',
                             collapsed: true,
@@ -90,7 +82,7 @@ function sidebarKagi() {
                                 { text: 'Work on Orion Browser', link: '/kagi/company/hiring-orion' },
                             ]
                         },
-                        { text: 'Donations', link: '/kagi/company/donations' },
+                        { text: 'Open Source Support', link: '/kagi/company/donations' },
                         { text: 'Contact Us', link: '/kagi/company/contact' },
                     ]
                 },
@@ -112,11 +104,8 @@ function sidebarKagi() {
                     collapsed: true,
                     link: '/kagi/support-and-community/',
                     items: [
-                        { text: 'Roadmap & Feedback Forum', link: '/kagi/support-and-community/roadmap_feedback' },
+                        { text: 'Get Connected', link: '/kagi/support-and-community/roadmap_feedback' },
                         { text: 'Reporting a Bug', link: '/kagi/support-and-community/bug-reporting' },
-                        { text: 'Email Support', link: '/kagi/support-and-community/email-support' },
-                        { text: 'Discord Server', link: '/kagi/support-and-community/discord-server' },
-                        { text: 'Blog', link: '/kagi/support-and-community/blog' },
                         { text: 'Share with Friends and Family', link: '/kagi/support-and-community/share-kagi' },
                     ]
                 },

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -73,7 +73,7 @@ function sidebarKagi() {
                         { text: 'About', link: '/kagi/company/' },
                         { text: 'Products', link: '/kagi/company/products' },
                         { text: 'History', link: '/kagi/company/history' },
-                         { text: 'Assets', link: '/kagi/company/assets' },
+                         { text: 'Press Kit', link: '/kagi/company/assets' },
                         {
                             text: 'Jobs', link: '/kagi/company/hiring-kagi',
                             collapsed: true,

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -73,7 +73,7 @@ function sidebarKagi() {
                         { text: 'About', link: '/kagi/company/' },
                         { text: 'Products', link: '/kagi/company/products' },
                         { text: 'History', link: '/kagi/company/history' },
-                         { text: 'Press Kit', link: '/kagi/company/assets' },
+                         { text: 'Assets', link: '/kagi/company/assets' },
                         {
                             text: 'Jobs', link: '/kagi/company/hiring-kagi',
                             collapsed: true,

--- a/docs/kagi/company/assets.md
+++ b/docs/kagi/company/assets.md
@@ -1,6 +1,6 @@
-# Kagi Search and Orion Press Kits
+# Kagi Assets and Orion Press Kits
 
-You can go to the [Kagi Press Kit](https://kagi.com/assets) webpage to access our resources and brand assets.
+You can go to the [Kagi Assets](https://kagi.com/assets) webpage to access our resources and brand assets.
 
 They include:
 

--- a/docs/kagi/company/assets.md
+++ b/docs/kagi/company/assets.md
@@ -1,4 +1,4 @@
-# Resources & Brand Assets
+# Kagi Search and Orion Press Kits
 
 You can go to the [Kagi Press Kit](https://kagi.com/assets) webpage to access our resources and brand assets.
 

--- a/docs/kagi/company/assets.md
+++ b/docs/kagi/company/assets.md
@@ -1,6 +1,6 @@
 # Resources & Brand Assets
 
-You can go to the [Kagi Assets](https://kagi.com/assets) webpage to access our resources and brand assets.
+You can go to the [Kagi Press Kit](https://kagi.com/assets) webpage to access our resources and brand assets.
 
 They include:
 

--- a/docs/kagi/company/donations.md
+++ b/docs/kagi/company/donations.md
@@ -1,4 +1,4 @@
-# Donations
+# Open Source Support
 
 We are making a monthly donation to the following projects:
 

--- a/docs/kagi/company/index.md
+++ b/docs/kagi/company/index.md
@@ -28,3 +28,32 @@ We hope that our work impacts people's lives in some small way for the better. T
 > "With Kagi and Orion, we’re striving to build better ways to experience the web, ways that are safe yet fun for everyone, including my own kids."
 >
 > —Vladimir Prelovac
+
+## What Does "Kagi" Mean?
+
+The word "kagi" means "key" in Japanese.
+
+Kagi is pronounced as kah-gee. You can [listen to the pronunciation](https://www.youtube.com/watch?v=ig4VTr0rt4Q).
+
+## Kagi Search Logo
+
+<img src="./media/kagi-logo.png" width="100" alt="Kagi Logo">
+
+More Kagi assets are available on the [Kagi Assets](https://kagi.com/assets) page.
+
+People sometimes ask why does Kagi have a "g" logo in the Google ballpark rather than a "k"?
+
+Our designer insisted the Kagi logo is "anchored" in the letter "g," and we had to agree. Besides, we can't let Google own the letter "g" too, can we? ;)
+
+## Orion Browser Logo
+
+<img src="./media/orion-logo.png" width="100" alt="Orion Logo">
+
+More Orion assets are available on the [Orion Press Kit](https://browser.kagi.com/press-kit/) page.
+
+
+## Who is Kagi's Mascot?
+
+We simply call him ”Doggo” for now. He's adorable!
+
+<img src="./media/doggo_1.png" width="350" alt="Doggo Kagi Mascot">

--- a/docs/kagi/support-and-community/roadmap_feedback.md
+++ b/docs/kagi/support-and-community/roadmap_feedback.md
@@ -1,31 +1,53 @@
-# Roadmap & Feedback Forum
+# Get Connected with Kagi
+
+## Blog
+
+We blog at [blog.kagi.com](https://blog.kagi.com/blog) about company updates product features and other important news.
+You can subscribe to our [blog's RSS feed](https://blog.kagi.com/rss.xml).
+
+Example content:
+
+- [Kagi search and Orion browser enter public beta](https://blog.kagi.com/kagi-orion-public-beta)
+- [Kagi passes an independent security audit](https://blog.kagi.com/security-audit)
+- [Kagi status update: First three months](https://blog.kagi.com/status-update-first-three-months)
+
+
+## Discord
+
+We have a [Kagi Search Discord server](https://kagi.com/discord) where you can join our community for real-time discussion about the product and chat with other Kagi users.
+
+Please use the **#introduce-yourself** channel to say hello and let everyone know a bit about you.
+
+We'd also love to hear your initial thoughts about Kagi Search on the **#first-impressions** channel.
+
+To make specific feature requests or bug reports, please use our [Kagi Search feedback forum](https://kagifeedback.org) rather than Discord.
+
+## Feedback Forum
+
+You can join [KagiFeedback.org](https://kagifeedback.org/) to see the bug reports and feature requests we are discussing, reviewing, and planning to address and to the discussion.
+
+- Please see our [Bug Reporting Guide](bug-reporting.md) for instructions on reporting issues.
+- All bugs and feature requests are encouraged to be posted on the forum.
 
 ## Roadmap
 
 Our community drives the future product direction of Kagi Search, and we hope you will become a part of it.
 Check out our [roadmap](https://kagifeedback.org/roadmap).
 
-## Release notes & RSS
+## Release Notes
 
-HTML version of release notes is available at:
+Release notes are published at:
 [kagi.com/changelog](https://kagi.com/changelog)
 
 RSS feed for release notes is available at:
 [kagifeedback.org/atom/t/release-notes](https://kagifeedback.org/atom/t/release-notes)
 
-## Forum
+## Customer Support
 
-You can join [KagiFeedback.org](https://kagifeedback.org/) to see the bug reports and feature requests we are discussing, reviewing, and planning to address
-and to the discussion.
+Before contating us for support please see if your issue has been addressed on this knowledge base or our [Kagi Search feedback forum](https://kagifeedback.org).
 
-- Please see our [Bug Reporting Guide](bug-reporting.md) for instructions on reporting issues.
-- All bugs and feature requests are encouraged to be posted on the forum.
+Feel free to [email us](email-support.md) or use the [Kagi Search Discord server](https://kagi.com/discord) for support.
 
-## Discord
 
-In addition, you can also [join our Discord!](discord-server.md) for real-time discussion about
-the product and chat with other Kagi users.
-
-## Email support
-
-Feel free to [email us](email-support.md) for support.
+## Twitter (er, X?)
+[KagiHQ on Twitter](https://twitter.com/KagiHQ)


### PR DESCRIPTION
* Use consistent language for "Press Kit" across Kagi and Orion (replace "assets" with "Press Kit")
* Consolidate pages under "Support and Community"; add link to KagiHQ twitter