### PR TITLE
Updated cryptocurrency information in the FAQs

### DIFF
--- a/docs/kagi/company/faqs.md
+++ b/docs/kagi/company/faqs.md
@@ -178,11 +178,9 @@ Check [Custom CSS](../features/custom-css.md). Also check [Kagi Discord](https:/
 
 ## Does Kagi support crypto / anonymous payments ?
 
-We are having a discussion about this in our community right now.
+We officially support OpenNode as a cryptocurrency payment option.
 
-See here https://kagifeedback.org/d/493-enable-anonymous-payments-ala-bitcoinmonero/
-
-Feel free to chime in with your thoughts.
+For more information, please read this [blog post](https://blog.kagi.com/accepting-paypal-bitcoin).
 
 ## Does Kagi have any student discounts?
 


### PR DESCRIPTION
Now that Kagi officially supports cryptocurrency payments, I've changed the "Does Kagi support crypto?" paragraph in the FAQ to link to a blog post about support.

At some point I thought I should also add documentation about cryptocurrency payments to the `Plans & Payment` section, but since I don't actually use cryptocurrency payments, I'll wait for another PR.