### PR TITLE
Add detail to Firefox on Android setup instructions

### DIFF
--- a/docs/kagi/getting-started/setting-default.md
+++ b/docs/kagi/getting-started/setting-default.md
@@ -150,6 +150,7 @@ To set up a private session link in Firefox, use [this extension](https://addons
     - In the **Search string to use** field, enter **https://kagi.com/search?q=%s**
     - Tap the confirmation button in the top right corner of the screen.
 
+If your browser is configured to default to private browsing, this will require you to log back in to Kagi each time your tabs are closed. To get around this, in the **Search string to use** field, use your [session link](https://kagi.com/settings?p=user_details) and append `&q=%s` at the end.
 
 <a name="firefox_ios"></a>
 #### iOS {#firefox_ios}


### PR DESCRIPTION
This adds a line to the instructions for setting up Kagi on Firefox on Android to clarify what to do if the browser is configured to default to private browsing.