### PR TITLE
Add search suggestion field to Firefox Android instructions

### DIFF
--- a/docs/kagi/getting-started/setting-default.md
+++ b/docs/kagi/getting-started/setting-default.md
@@ -158,6 +158,7 @@ To set up a private session link in Firefox, use [this extension](https://addons
 6. Tap the **Other** radio button to add a search engine and do the following:
     - in the **Name** field, enter **Kagi**.
     - In the **Search string to use** field, enter **https://kagi.com/search?q=%s**
+    - In the **Search suggestion API (optional)** field, enter **https://kagi.com/api/autosuggest?q=%s** 
     - Tap the confirmation button in the top right corner of the screen.
 
 If your browser is configured to default to private browsing, this will require you to log back in to Kagi each time your tabs are closed. To get around this, in the **Search string to use** field, use your [session link](https://kagi.com/settings?p=user_details) and append `&q=%s` at the end.


### PR DESCRIPTION
I'm not sure when this was added, but the field is present in Firefox Android v117.0.1.

<details>
<summary>Screenshot</summary>
![image](https://github.com/kagisearch/kagi-docs/assets/12981608/a7008de9-212c-4337-811a-2613eead8c1c)
</details>