### PR TITLE
clarify bang search usage

### DIFF
--- a/docs/kagi/features/bangs.md
+++ b/docs/kagi/features/bangs.md
@@ -1,6 +1,6 @@
 # Bangs
 
-Bangs are shortcuts starting with exclamation points (!) that quickly take you to search results on other sites. For example, searching Kagi for **!w Monty Python** will search Wikipedia directly for "Monty Python" and take you to that Wikipedia search result. Bangs are [never counted as searches](../plans/plan-types.md#how-searches-are-counted) for the purpose of billing/usage.
+Bangs are shortcuts starting with exclamation points (!) that quickly take you to search results on other sites. For example, searching Kagi for **!w Monty Python** will search Wikipedia directly for "Monty Python" and take you to that Wikipedia search result. Bangs that perform searches on external sites are [never counted as searches](../plans/plan-types.md#how-searches-are-counted) for the purpose of billing/usage.
 
 ![Bang Example](media/bang.gif)
 


### PR DESCRIPTION
bangs that provide a shortcut to Kagi UI (e.g. !i, !m, !sum) should still count as a used search, since it's routing the search within Kagi. Bangs that use external sites search system won't use a search.