### PR TITLE
Add note that not all extensions set kagi as default

### DIFF
--- a/docs/kagi/getting-started/setting-default.md
+++ b/docs/kagi/getting-started/setting-default.md
@@ -50,7 +50,7 @@ A modal will appear, click the **Get Your Session Link** button to get the link 
 <a name="browser_extension"></a>
 ## Option 2: Using the Kagi Browser Extension {#browser_extension}
 
-Kagi is available as an extension for all major browsers. The extension sets Kagi as the default search engine and allows you to **search with Kagi even in a private window without logging in** (this can be also set manually with the use of a [private session link](#private_session)).
+Kagi is available as an extension for all major browsers. The extension sets Kagi as the default search engine on some browsers/platforms and allows you to **search with Kagi even in a private window without logging in** (this can be also set manually with the use of a [private session link](#private_session)).
 
 Extension download links:
 


### PR DESCRIPTION
Related to https://github.com/kagisearch/browser_extensions/issues/2

Another option would be to display a table of browsers to supported features. It could make it easy to identify if extra work is needed to setup Kagi.