### PR TITLE
Update Extensions menu location

### DIFF
--- a/docs/orion/support-and-community/troubleshooting/troubleshooting-extension-issues.md
+++ b/docs/orion/support-and-community/troubleshooting/troubleshooting-extension-issues.md
@@ -16,7 +16,7 @@ Here are some extra things you can do to help us debug this:
 
 
 
-- Copy console errors from background-script [Window->Extensions->Console (from options popup button for specific web-extension)]
+- Copy console errors from background-script [Tools->Extensions->Console (from options popup button for specific web-extension)]
 
 <img src="../media/debug_ext.png" width="700" alt="Enable extension console"><br />
 


### PR DESCRIPTION
The "Extensions" sub-menu has moved from the "Window" menu to the "Tools" menu, this updates the docs to reflect the same.