### PR TITLE
Change closed beta to open beta

### DIFF
--- a/docs/kagi/ai/assistant.md
+++ b/docs/kagi/ai/assistant.md
@@ -2,7 +2,7 @@
 
 Kagi Assistant is a product feature backed by Kagi Search and large language models.
 
-> Kagi Assistant is currently in closed beta only available to Ultimate plan members.
+> Kagi Assistant is currently in open beta only available to Ultimate plan members.
 
 ## Assistant Modes
 


### PR DESCRIPTION
The Assistant features do not require an invite to access, which makes it an open beta rather than a closed beta.

See https://kagifeedback.org/d/2838-assistant-is-referred-to-as-a-private-or-closed-beta-when-it-is-not for rationale and resources on the matter.