### PR TITLE
Update fastgpt.md

### DIFF
--- a/docs/kagi/api/fastgpt.md
+++ b/docs/kagi/api/fastgpt.md
@@ -1,6 +1,6 @@
 # FastGPT
 
-[FastGPT](https://labs.kagi.com/fastgpt) is a Kagi service using powerful LLMs to answer user queries running a full search engine underneath. Think ChatGPT, but on steroids and faster! You can try the web app [here](https://labs.kagi.com/fastgpt).
+[FastGPT](https://kagi.com/fastgpt) is a Kagi service using powerful LLMs to answer user queries running a full search engine underneath. Think ChatGPT, but on steroids and faster! You can try the web app [here](https://kagi.com/fastgpt).
 
 ## Quick start
 


### PR DESCRIPTION
Correcting (?) the links to FastGPT here, which no longer go to a labs subdomain.

(The labs subdomain takes me to a Google login.)