### PR TITLE
Fixed incorect apostrophe in privacy doc

### DIFF
--- a/docs/kagi/privacy/privacy-protection.md
+++ b/docs/kagi/privacy/privacy-protection.md
@@ -28,6 +28,6 @@ Note that you can register for Kagi Search with any email address you control. Y
 
 Let us reiterate that we do not log searches or in any way tie them to an account. We simply have no incentive to do it. Our business model is to sell subscriptions, not user data.
 
-Kagi's business model is unlike any other search engine. This means we don’t need or want your personal information (it would just be an unwelcome liability). In fact, the only data we store is an email address. That can be any email address, as long as you can use it to recover your account. There is no other personal information shared with Kagi.
+Kagi's business model is unlike any other search engine. This means we don't need or want your personal information (it would just be an unwelcome liability). In fact, the only data we store is an email address. That can be any email address, as long as you can use it to recover your account. There is no other personal information shared with Kagi.
 
 By choosing this business model, we will have far fewer users than mainstream search engines. But we have also removed any incentive to misuse the information you have shared with us.

--- a/docs/kagi/privacy/privacy-protection.md
+++ b/docs/kagi/privacy/privacy-protection.md
@@ -28,6 +28,6 @@ Note that you can register for Kagi Search with any email address you control. Y
 
 Let us reiterate that we do not log searches or in any way tie them to an account. We simply have no incentive to do it. Our business model is to sell subscriptions, not user data.
 
-Kagi’s business model is unlike any other search engine. This means we don’t need or want your personal information (it would just be an unwelcome liability). In fact, the only data we store is an email address. That can be any email address, as long as you can use it to recover your account. There is no other personal information shared with Kagi.
+Kagi's business model is unlike any other search engine. This means we don’t need or want your personal information (it would just be an unwelcome liability). In fact, the only data we store is an email address. That can be any email address, as long as you can use it to recover your account. There is no other personal information shared with Kagi.
 
 By choosing this business model, we will have far fewer users than mainstream search engines. But we have also removed any incentive to misuse the information you have shared with us.


### PR DESCRIPTION
Fixed incorrect apostrophe, causing a space in the docs.

Screenshot of issue:

![image](https://github.com/kagisearch/kagi-docs/assets/25888319/8d5d5f28-174c-473f-8a9e-48a1fea5b11e)