### PR TITLE
Adding link to an apple shortcut script for Kagi AI

### DIFF
--- a/docs/kagi/community-addons/index.md
+++ b/docs/kagi/community-addons/index.md
@@ -43,7 +43,7 @@ Adds a button to the right click context menu on Firefox that allows you to open
 
 [Summarize URL](https://www.icloud.com/shortcuts/8d2668c84ad34203b47c519e066ce205): Summarize any URL using the Share Sheet or your Clipboard on your iPhone, iPad or Mac - Credits to [Sean Chou](https://twitter.com/sychou)
 
-[Ask Kagi](https://www.icloud.com/shortcuts/072ba261469b40e2af7ca49e57adf9a1): Ask Kagi's FastGPT AI questions, Siri will read out the result. Great for idle questions in the car! You must insert your own API key, get your API key [here](https://help.kagi.com/kagi/api/fastgpt.html#quick-start) - Credits to [Alex Schuldberg](https://bsky.app/profile/schuldberg.com)
+[Ask Kagi](https://www.icloud.com/shortcuts/c92d096f37984fe4b756a6ff2eafc795): Ask Kagi's FastGPT AI questions, Siri will read out the result. Great for idle questions in the car! You must insert your own API key, get your API key [here](https://help.kagi.com/kagi/api/fastgpt.html#quick-start) - Credits to [Alex Schuldberg](https://bsky.app/profile/schuldberg.com)
 
 ## Script Kit
 

--- a/docs/kagi/community-addons/index.md
+++ b/docs/kagi/community-addons/index.md
@@ -43,6 +43,8 @@ Adds a button to the right click context menu on Firefox that allows you to open
 
 [Summarize URL](https://www.icloud.com/shortcuts/8d2668c84ad34203b47c519e066ce205): Summarize any URL using the Share Sheet or your Clipboard on your iPhone, iPad or Mac - Credits to [Sean Chou](https://twitter.com/sychou)
 
+[Ask Kagi](https://www.icloud.com/shortcuts/072ba261469b40e2af7ca49e57adf9a1): Ask Kagi's FastGPT AI questions, Siri will read out the result. Great for idle questions in the car! You must insert your own API key, get your API key [here](https://help.kagi.com/kagi/api/fastgpt.html#quick-start) - Credits to [Alex Schuldberg](https://bsky.app/profile/schuldberg.com)
+
 ## Script Kit
 
 - [FastGPT for Script Kit](https://scriptkit.com/api/new?name=kagi-fastgpt&url=https://gist.githubusercontent.com/awakenedhaggis/bd9dbf2421325117f7e5c20f62e1c99f/raw/9ab7d843fdfb2bf3b1e3c65e5c4774fe896abc91/kagi-fastgpt.ts): Access our [FastGPT API](../api/fastgpt.md) directly from your desktop using Script Kit.


### PR DESCRIPTION
Adding a link to an apple shortcut script for Kagi, which allows users to ask Kagi Fast GPT questions and receive a spoken word response. Also included a link for how to get your own API Key.