### PR TITLE
Update bangs.md to fix `\ query` bang search

### DIFF
--- a/docs/kagi/features/bangs.md
+++ b/docs/kagi/features/bangs.md
@@ -190,4 +190,4 @@ Here is the full list of "feeling lucky" patterns that we support:
 
 - `! query`
 - `query !`
-- `\query`
+- `\ query`


### PR DESCRIPTION
add a space between `\ query` b/c `\query` just goes to kagi's search page while `\(space)query` actually does what you expect