### PR TITLE
Update summarizer.md

### DIFF
--- a/docs/kagi/api/summarizer.md
+++ b/docs/kagi/api/summarizer.md
@@ -228,7 +228,7 @@ Engine | Description
 -------|-----------
 cecil (default) | Friendly, descriptive, fast summary
 agnes  | Formal, technical, analytical summary
-daphne | Informal, creative, friendly summary
+daphne | Same as Agnes (Soon to be depracated)
 muriel | Best-in-class summary using our enterprise-grade model
 
 ### Target Language Codes


### PR DESCRIPTION
Clarify that Daphne model is soon to be deprecated and points to same model as Agnes in Summarizer API page