### PR TITLE
remove raivo and added ente to 2FA app list

### DIFF
--- a/docs/kagi/privacy/two-factor-authentication.md
+++ b/docs/kagi/privacy/two-factor-authentication.md
@@ -10,7 +10,7 @@ Kagi’s 2FA implementation is compatible with most authenticator apps, some opt
 
 iOS:
 - [2FAS Authenticator](https://apps.apple.com/us/app/2fas-auth/id1217793794) (Open Source)
-- [Raivo Authenticator](https://apps.apple.com/us/app/raivo-authenticator/id1459042137)  
+- [Ente Authenticator](https://apps.apple.com/us/app/ente-auth/id6444121398)  
 - [Google Authenticator](https://apps.apple.com/us/app/google-authenticator/id388497605)  
 - [Microsoft Authenticator](https://apps.apple.com/us/app/microsoft-authenticator/id983156458)  
 


### PR DESCRIPTION
This PR removed raivo from the listed 2FA apps. Recently they were acquired by another developer who pushed out a release which broke a majority of users 2FA keys, and even if you were able to recover them, they put exporting of the keys behind a paywall. The app currently sits with a 1.4 rating in the app store so perhaps it should be swapped out for another alternative such as ente?

Open to suggestions on this.