### PR TITLE
Update payment-methods.md

### DIFF
--- a/docs/kagi/plans/payment-methods.md
+++ b/docs/kagi/plans/payment-methods.md
@@ -15,11 +15,13 @@ You can pay for Kagi's products and services using any of the payment methods li
   - Bitcoin
   - Bitcoin Lightning
 
-*\* Please note that PayPal fees will be added to the transaction amount.*
+\* _Please note that PayPal fees will be added to the transaction amount._
 
 ## Using PayPal and OpenNode with Kagi
 
 PayPal and OpenNode can only be used to [add prepaid funds](https://kagi.com/settings?p=account_topup) to your Kagi account, which can then be used towards any of our plans.  
 If you added prepaid funds and haven't subscribed to one of our plans yet, you can do so from the [Plan Selection](https://kagi.com/settings?p=billing_plan) page.
+
+After choosing your plan, you will be redirected to Stripe to confirm your subscription. This is required because we use Stripe to manage all subscriptions, regardless of the payment method used.
 
 If you have any questions about our payment methods or need help with your subscription, please don't hesitate to reach out to our support team at [support@kagi.com](mailto:support@kagi.com).


### PR DESCRIPTION
Clarify that PayPal and OpenNode payments will still redirect user to Stripe as we use it to manage all subscriptions