### PR TITLE
Remove references to old discord server

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -12,14 +12,10 @@ contact_links:
     url: https://kagifeedback.org
     about: If you have found a bug or have feedback for Kagi Search that is unrelated to the API or documentation, please open a ticket on this forum.
 
-  - name: Kagi Search Discord Server
+  - name: Kagi Discord Server
     url: https://kagi.com/discord
-    about: Chat with the Kagi Search developers and community for small questions, sharing ideas, and casual discussion.
+    about: Chat with the Kagi and Orion developers and community for small questions, sharing ideas, and casual discussion.
 
   - name: Orion Browser feedback, bug reports, and feature requests
     url: https://orionfeedback.org
     about: If you have found a bug or have feedback for the Orion Browser that is unrelated to its documentation, please open a ticket on this forum.
-
-  - name: Orion Browser Discord Server
-    url: https://discord.gg/EMMzT57hQT
-    about: Chat with the Orion developers and community for small questions, sharing ideas, and casual discussion.

--- a/README.md
+++ b/README.md
@@ -45,13 +45,15 @@ official support venues, in the [Community](#community) section.
 
 ### Community
 
-Each of our products has their own budding community. You can join us for
-wider discussion and product support at their dedicated venues:
+Each of our products has their own forum, and we encourage you to join us there.
+We also have a shared Discord server where you can discuss all of our products.
 
-Product | Feedback & Bug Reports | Discord
---------|------------------------|------------
-Kagi Search | [kagifeedback.org](https://kagifeedback.org) | [Invite Link](https://kagi.com/discord)
-Orion Browser | [orionfeedback.org](https://orionfeedback.org) | [Invite Link](https://discord.gg/EMMzT57hQT)
+Discord Invite: https://kagi.com/discord
+
+Product | Feedback & Bug Reports
+--------|-----------------------
+Kagi Search | [kagifeedback.org](https://kagifeedback.org)
+Orion Browser | [orionfeedback.org](https://orionfeedback.org)
 
 ## Contributing
 

--- a/docs/common/company/history.md
+++ b/docs/common/company/history.md
@@ -41,7 +41,7 @@ First prototype of Orion browser with support for web extensions on iOS is made,
 
 2023
 
-- [Kagi raises $670K](https://blog.kagi.com/safe-round) from its users in its first external fundraise. Total money invested nears $5M at this point.
+- [Kagi raises $670K](https://blog.kagi.com/safe-round) from its users in its first external fundraiser. Total money invested nears $5M at this point.
 - We publish our [live stats](https://kagi.com/stats)
 - We cross $1M annual revenue milestone, offering paid web search and paid web browser product
 - Kagi Assistant enters public beta 

--- a/docs/kagi/api/summarizer.md
+++ b/docs/kagi/api/summarizer.md
@@ -228,7 +228,7 @@ Engine | Description
 -------|-----------
 cecil (default) | Friendly, descriptive, fast summary
 agnes  | Formal, technical, analytical summary
-daphne | Same as Agnes (Soon-to-be-depracated)
+daphne | Same as Agnes (Soon-to-be-deprecated)
 muriel | Best-in-class summary using our enterprise-grade model
 
 ### Target Language Codes

--- a/docs/kagi/getting-started/setting-default.md
+++ b/docs/kagi/getting-started/setting-default.md
@@ -242,7 +242,7 @@ To set up a private session link in Firefox:
 6. Select the new "Kagi Search" as your default search engine using the dropdown at the top of this page.
 
 There is currently no way to manually set the 'Search suggestion API' for a search engine in Firefox desktop.
-Instaling [the extension](#browser_extension) does allow you to use suggestions.
+Installing [the extension](#browser_extension) does allow you to use suggestions.
 
 <a name="firefox_android_mobile"></a>
 #### Android Mobile {#firefox_android_mobile}

--- a/docs/kagi/index.md
+++ b/docs/kagi/index.md
@@ -10,7 +10,7 @@ You can access our documentation in several ways:
 - Click or tap the magnifying glass icon at the top of the screen and do a search.
 - Use the **!help** [bang](/kagi/features/bangs.md) in Kagi Search. For example, searching in Kagi for [!help setting Kagi as default search engine](https://kagi.com/search?q=!help%20setting%20kagi%20as%20default%20search%20engine) will show you results containing our default search documentation.
 
-Feedback about this Kagi Search documentation can be shared on our [Discord Server](https://kagi.com/discord) in the **\#documentation** channel. We would love to hear your thoughts on anything we can fix or improve.
+Feedback about this Kagi Search documentation can be shared on our [Discord server](https://kagi.com/discord) in the **\#documentation** channel. We would love to hear your thoughts on anything we can fix or improve.
 
 ## About Kagi Search
 

--- a/docs/orion/faq/faq.md
+++ b/docs/orion/faq/faq.md
@@ -273,7 +273,8 @@ wizzair.com - Interference with rendering of the website
 ## Help! A site isn’t working! {#compatibility}
 Orion has a "Compatibility mode" in the settings menu. Turning it on will suspend your currently running extensions (the most common cause of problems) and record the setting for this website so it works when you visit it again. 
 
-If the site still fails, you may want to test it in Safari. If it works there, please report the problem to us via our [Orion beta Discord server](https://discord.com/invite/gKh5E6ys6D).
+If the site still fails, you may want to test it in Safari. If it works there,
+please report the problem to us via our [Discord server](https://kagi.com/discord).
 
 <a name="issuetracker"></a>
 ## Is there a public issue tracker? {#issuetracker}

--- a/docs/orion/index.md
+++ b/docs/orion/index.md
@@ -12,7 +12,7 @@ You can access our documentation in several ways:
 - Click or tap the magnifying glass icon at the top of the screen and do a search.
 - Use the **!orion** [bang](../kagi/features/bangs.md) in [Kagi Search](https://kagi.com). For example, searching in Kagi for [!orion setting default search engine](https://kagi.com/search?q=!orion%20setting%20default%20search%20engine) will show you results containing our documentation on how to set Orion's default search engine.
  
-Feedback about this Orion documentation can be shared on our [Discord Server](https://discord.com/invite/gKh5E6ys6D) in the **\#documentation** channel. We would love to hear your thoughts on anything we can fix or improve.
+Feedback about this Orion documentation can be shared on our [Discord server](https://kagi.com/discord) in the **\#documentation** channel. We would love to hear your thoughts on anything we can fix or improve.
 
 ## Contributing
 

--- a/docs/orion/support-and-community/contribute.md
+++ b/docs/orion/support-and-community/contribute.md
@@ -21,7 +21,7 @@ and to the discussion.
 
 ## Discord
 
-In addition, you can also [join our Discord!](discord-server.md) for real-time discussion about
+In addition, you can also [join our Discord](discord-server.md) for real-time discussion about
 the product and chat with other Orion users.
 
 ## Documentation

--- a/docs/orion/support-and-community/troubleshooting/bug-reporting.md
+++ b/docs/orion/support-and-community/troubleshooting/bug-reporting.md
@@ -15,7 +15,7 @@ for any bug report. lease include a clear list of instructions to reproduce the 
 If we can not reproduce the problem, we are not able to fix it.
 
 **Important note**: Most likely cause of problems on web pages is Content blocking
-and Web extension. You can rule out both quickly by enabling [Compatibilty mode](./troubleshooting-webpage-issues.md#orion-compatibility-mode).
+and Web extension. You can rule out both quickly by enabling [Compatibility mode](./troubleshooting-webpage-issues.md#orion-compatibility-mode).
 
 The second most likely cause of issues is WebKit, Orion's rendering engine.
 This is why we will ask you to check if the same problems exists in Safari
@@ -50,7 +50,7 @@ About menu if unsure. There is a lot of debug information available in Help
 
 Sometimes there are a few things you can do to help us narrow down certain issues. Depending on the problem, you can try:
 
-- Turn on [Compatibilty mode](./troubleshooting-webpage-issues.md#orion-compatibility-mode)
+- Turn on [Compatibility mode](./troubleshooting-webpage-issues.md#orion-compatibility-mode)
 - Disabling all browser extensions
 - Restarting Orion
 


### PR DESCRIPTION
There still is one reference to the old discord server, hiring-orion.md, referring to the orion browser community event in dec2023. Not sure if I should change that or keep it for now.

Also rewords a few sentences because there is only one server now.

Fixes a few minor typos/capitalization issues