### PR TITLE
Fix "next" button behavior in Orion sidebar

### DIFF
--- a/docs/orion/features/compact-tabs.md
+++ b/docs/orion/features/compact-tabs.md
@@ -1,3 +1,9 @@
+---
+next:
+  text: 'Link Previews'
+  link: '/orion/features/link-previews'
+---
+
 # Compact Tabs
 
 Compact Tabs is a feature available in Orion for Mac that condenses your open tabs into a single, compact bar, located next to the address bar, allowing you to see more of your webpage and less of the browser's interface.

--- a/docs/orion/features/website-settings.md
+++ b/docs/orion/features/website-settings.md
@@ -1,9 +1,3 @@
----
-next:
-  text: 'Password Management'
-  link: '/orion/features/password-management'
----
-
 # Website Settings
 
 ## Table of Contents


### PR DESCRIPTION
Fix "next" button behavior in Orion sidebar