### PR TITLE
add url parameter for assistant to docs

### DIFF
--- a/docs/kagi/ai/assistant.md
+++ b/docs/kagi/ai/assistant.md
@@ -170,13 +170,13 @@ You can also access the **Code** Custom Assistant with the `!code` bang.
 
 You can specify a particular model in the Assistant's URL by including a `profile` parameter.
 `https://kagi.com/assistant?profile=gpt-4o&q=%s`
-The available model names include: `gpt-4`, `gpt-4-turbo`, `gpt-4o`, `gpt-4o-mini`, `gemini-pro`, `mistral-nemo`, `mistral-large`, `claude-3-haiku`, `claude-3-sonnet`, `claude-3-opus`, `llama-3-405b`, `code`
+The available model names include: `gpt-4`, `gpt-4-turbo`, `gpt-4o`, `gpt-4o-mini`, `gemini-pro`, `mistral-nemo`, `mistral-large`, `claude-3-haiku`, `claude-3-sonnet`, `claude-3-opus`, `llama-3-405b`, `code`.
 
 This can also be used with custom assistants, as described on the [custom assistant documentation](./custom-assistants.md#url-parameters).
 
 The `internet` parameter can be used to turn on and off internet access, set to `true` to enable, anything else to disable. This overrides the internet setting of the profile used.
 
-The `lens` parameter can be used to set the lens if internet access is enabled. The value of this is the lowercase format of the lens name, for example, `https://kagi.com/assistant?lens=programming&q=%s`.
+The `lens` parameter can be used to set the lens if internet access is enabled. The value of this is the lowercase format of the lens name, for example, `https://kagi.com/assistant?lens=programming&q=%s` will use the Programming lens.
 
 ## Availability
 

--- a/docs/kagi/ai/assistant.md
+++ b/docs/kagi/ai/assistant.md
@@ -166,23 +166,11 @@ You can quickly access Assistant from Kagi Search by using the following [bangs]
 
 You can also access the **Code** Custom Assistant with the `!code` bang.
 
-For this addition, a natural location would be right after the **LLMs Available in The Assistant** section, adding a clear explanation on the use of the `profile` parameter to select a specific LLM, like `gpt-4o` or `claude3.5`. Here's the updated content for that section:
-
 ## URL Parameter for Model Selection
 
 You can specify a particular model in the Assistant's URL by including a `profile` parameter.
-`https://kagi.com/assistant?profile=gpt_4o&q={{{s}}}`
+`https://kagi.com/assistant?profile=gpt_4o&q=%s`
 The available model names include: `gpt_4o` `gpt_4o_mini` `gpt_4` `gpt_4_turbo` `claude_3_haiku` `claude_3_opus` `claude_3_sonnet` `code` `gemini_pro` `llama-3-405b` `mistral_pixtral` `mistral_large`
-
-### Example Usage:
-
-To use GPT-4o specifically, you can configure your request with:
-
-```
-/assistant?q=%s&profile=gpt-4o
-```
-
-For custom assistants, you can use the UUID by navigating to the Assistant settings page, selecting the assistant to view its URL, and copying the UUID. Replace `profile=UUID-HERE` in your bang URL with this UUID to direct the request to your custom assistant.
 
 ## Availability
 

--- a/docs/kagi/ai/assistant.md
+++ b/docs/kagi/ai/assistant.md
@@ -166,6 +166,24 @@ You can quickly access Assistant from Kagi Search by using the following [bangs]
 
 You can also access the **Code** Custom Assistant with the `!code` bang.
 
+For this addition, a natural location would be right after the **LLMs Available in The Assistant** section, adding a clear explanation on the use of the `profile` parameter to select a specific LLM, like `gpt-4o` or `claude3.5`. Here's the updated content for that section:
+
+## URL Parameter for Model Selection
+
+You can specify a particular model in the Assistant's URL by including a `profile` parameter.
+`https://kagi.com/assistant?profile=gpt_4o&q={{{s}}}`
+The available model names include: `gpt_4o` `gpt_4o_mini` `gpt_4` `gpt_4_turbo` `claude_3_haiku` `claude_3_opus` `claude_3_sonnet` `code` `gemini_pro` `llama-3-405b` `mistral_pixtral` `mistral_large`
+
+### Example Usage:
+
+To use GPT-4o specifically, you can configure your request with:
+
+```
+/assistant?q=%s&profile=gpt-4o
+```
+
+For custom assistants, you can use the UUID by navigating to the Assistant settings page, selecting the assistant to view its URL, and copying the UUID. Replace `profile=UUID-HERE` in your bang URL with this UUID to direct the request to your custom assistant.
+
 ## Availability
 
 The Assistant is available to all Kagi Ultimate members.

--- a/docs/kagi/ai/assistant.md
+++ b/docs/kagi/ai/assistant.md
@@ -31,7 +31,7 @@ When you use the Assistant by Kagi, your data is never used to train AI models, 
 
 ## Using the Assistant
 
-The Assistant can be accessed via the Control Center located in the top right corner of all Kagi pages or by clicking on the link in the top right corner of the Kagi homepage. [The direct link](https://kagi.com/assistant) to the Assistant can also be used. 
+The Assistant can be accessed via the Control Center located in the top right corner of all Kagi pages or by clicking on the link in the top right corner of the Kagi homepage. [The direct link](https://kagi.com/assistant) to the Assistant can also be used.
 
 When you first access the Assistant, you will be greeted by a familiar-looking landing page, allowing you to get right into using it.
 You can either type your prompt or use voice input by pressing the microphone symbol.
@@ -166,11 +166,17 @@ You can quickly access Assistant from Kagi Search by using the following [bangs]
 
 You can also access the **Code** Custom Assistant with the `!code` bang.
 
-## URL Parameter for Model Selection
+## URL Parameters
 
 You can specify a particular model in the Assistant's URL by including a `profile` parameter.
-`https://kagi.com/assistant?profile=gpt_4o&q=%s`
-The available model names include: `gpt_4o` `gpt_4o_mini` `gpt_4` `gpt_4_turbo` `claude_3_haiku` `claude_3_opus` `claude_3_sonnet` `code` `gemini_pro` `llama-3-405b` `mistral_pixtral` `mistral_large`
+`https://kagi.com/assistant?profile=gpt-4o&q=%s`
+The available model names include: `gpt-4`, `gpt-4-turbo`, `gpt-4o`, `gpt-4o-mini`, `gemini-pro`, `mistral-nemo`, `mistral-large`, `claude-3-haiku`, `claude-3-sonnet`, `claude-3-opus`, `llama-3-405b`, `code`
+
+This can also be used with custom assistants, as described on the [custom assistant documentation](./custom-assistants.md#url-parameters).
+
+The `internet` parameter can be used to turn on and off internet access, set to `true` to enable, anything else to disable. This overrides the internet setting of the profile used.
+
+The `lens` parameter can be used to set the lens if internet access is enabled. The value of this is the lowercase format of the lens name, for example, `https://kagi.com/assistant?lens=programming&q=%s`.
 
 ## Availability
 

--- a/docs/kagi/ai/custom-assistants.md
+++ b/docs/kagi/ai/custom-assistants.md
@@ -47,6 +47,18 @@ Remember that well-crafted instructions lead to more accurate and useful respons
 
 Select your Custom Assistant from the model-selection dropdown menu below the prompt bar to begin interaction.
 
+## URL Parameter for Custom Assistants
+
+You can specify a custom assistant by adding a `profile` parameter to the URL, using either the name (in lowercase, hyphenated format) or the UUID of your custom assistant.
+
+For instance, if you want to use a specific custom assistant, locate its UUID by navigating to your [Custom Assistants settings page](https://kagi.com/settings?p=assistant), and copy the long UUID found in the URL when editing the assistant. You can then create a custom bang template, like:
+
+```
+/assistant?q=%s&profile=c03f3098-9ead-408f-93f0-407a77e697db
+```
+
+This setup will direct the request to your specified assistant.
+
 ## Default Custom Assistants
 
 The Assistant comes with carefully pre-configured assistants designed to enhance your productivity.

--- a/docs/kagi/ai/custom-assistants.md
+++ b/docs/kagi/ai/custom-assistants.md
@@ -47,9 +47,9 @@ Remember that well-crafted instructions lead to more accurate and useful respons
 
 Select your Custom Assistant from the model-selection dropdown menu below the prompt bar to begin interaction.
 
-## URL Parameter for Custom Assistants
+## URL Parameters
 
-You can specify a custom assistant by adding a `profile` parameter to the URL, using either the name (in lowercase, hyphenated format) or the UUID of your custom assistant.
+You can specify a custom assistant by adding a `profile` parameter to the URL, using either the name (in lowercase format) or the UUID of your custom assistant.
 
 For instance, if you want to use a specific custom assistant, locate its UUID by navigating to your [Custom Assistants settings page](https://kagi.com/settings?p=assistant), and copy the long UUID found in the URL when editing the assistant. You can then create a custom bang template, like:
 
@@ -58,6 +58,8 @@ For instance, if you want to use a specific custom assistant, locate its UUID by
 ```
 
 This setup will direct the request to your specified assistant.
+
+More information about assistant URL parameters can be found in the [assistant documentation](./assistant.md#url-parameters)
 
 ## Default Custom Assistants
 
@@ -120,4 +122,3 @@ Here are a few example configurations you can use to get started. You can also v
 | Internet Access | Enabled (for current events) |
 | Lens | World News |
 | Instructions | Analyze current events with balanced perspective. Provide context for news developments. Focus on factual reporting and multiple viewpoints. Summarize key points clearly. |
-

--- a/docs/kagi/ai/custom-assistants.md
+++ b/docs/kagi/ai/custom-assistants.md
@@ -59,7 +59,7 @@ For instance, if you want to use a specific custom assistant, locate its UUID by
 
 This setup will direct the request to your specified assistant.
 
-More information about assistant URL parameters can be found in the [assistant documentation](./assistant.md#url-parameters)
+More information about assistant URL parameters can be found in the [assistant documentation](./assistant.md#url-parameters).
 
 ## Default Custom Assistants
 


### PR DESCRIPTION
I also would have not known it was a thing if I hadn't seen it on discord. but it's not actually mentioned in the docs yet

https://kagifeedback.org/d/5254-hyperlink-directly-to-specific-assistants