### PR TITLE
Add instructions for opening specific profiles in Raycast launcher

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -365,6 +365,7 @@ function sidebarOrion() {
                         { text: 'Installing Orion', link: '/orion/getting-started/installing-orion' },
                         { text: 'Importing Data From Other Browsers', link: '/orion/getting-started/importing' },
                         { text: 'Default Search Engine', link: '/orion/getting-started/search-engine' },
+                        { text: 'Application Integrations', link: '/orion/getting-started/application-integrations' },
                     ]
                 },
                 {

--- a/docs/orion/features/profiles.md
+++ b/docs/orion/features/profiles.md
@@ -36,13 +36,3 @@ You can access this setting by following these steps:
 2. From the General tab, select your desired option in the **Open External Links In** dropdown.
 
 ![Orion - Open External Links in Last/Default Profile](./media/open_external_links_in_last_or_default_profile.gif){data-zoomable}
-
-## Open a Specific Profile in Raycast
-
-Orion creates a new app for each profile (eg. "Orion - Work.app"), contained within its own folder in `~/Applications/Orion/Orion Profiles/`. To make these profile-apps accessible from the Raycast launcher,
-1. Open Raycast settings
-2. Select the "Applications" extension group, under the Extensions tab
-3. Click on "Add Directories"
-4. Add all the *subdirectories* of `~/Applications/Orion/Orion Profiles/` (adding `Orion Profiles` itself does nothing)
-
-These instructions should generally work for similar launcher apps, if they have the capability to add directories in a similar manner.

--- a/docs/orion/features/profiles.md
+++ b/docs/orion/features/profiles.md
@@ -36,3 +36,13 @@ You can access this setting by following these steps:
 2. From the General tab, select your desired option in the **Open External Links In** dropdown.
 
 ![Orion - Open External Links in Last/Default Profile](./media/open_external_links_in_last_or_default_profile.gif){data-zoomable}
+
+## Open a Specific Profile in Raycast
+
+Orion creates a new app for each profile (eg. "Orion - Work.app"), contained within its own folder in `~/Applications/Orion/Orion Profiles/`. To make these profile-apps accessible from the Raycast launcher,
+1. Open Raycast settings
+2. Select the "Applications" extension group, under the Extensions tab
+3. Click on "Add Directories"
+4. Add all the *subdirectories* of `~/Applications/Orion/Orion Profiles/` (adding `Orion Profiles` itself does nothing)
+
+These instructions should generally work for similar launcher apps, if they have the capability to add directories in a similar manner.

--- a/docs/orion/getting-started/application-integrations.md
+++ b/docs/orion/getting-started/application-integrations.md
@@ -1,4 +1,4 @@
-# Integrating Kagi with Other Applications
+# Integrating Orion with Other Applications
 
 Orion can be integrated with other applications, such as launchers.
 

--- a/docs/orion/getting-started/application-integrations.md
+++ b/docs/orion/getting-started/application-integrations.md
@@ -1,0 +1,15 @@
+# Integrating Kagi with Other Applications
+
+Orion can be integrated with other applications, such as launchers.
+
+## Raycast
+
+[Raycast](https://raycast.com/) is a collection of powerful productivity tools, built as an extendable Spotlight-like launcher. 
+
+By default, Raycast cannot open specific Orion profiles, as Orion creates a new app for each profile (eg. "Orion - Work.app"), contained within its own folder in `~/Applications/Orion/Orion Profiles/`. To make these profile-apps accessible from the Raycast launcher,
+1. Open Raycast settings
+2. Select the **Applications** extension group, under the **Extensions** tab
+3. Click on **Add Directories** in the sidebar on the right
+4. Add all the *subdirectories* of `~/Applications/Orion/Orion Profiles/` (adding `Orion Profiles` itself does nothing)
+
+These instructions should generally work for similar launcher apps, if they have the capability to add directories in a similar manner.


### PR DESCRIPTION
Raycast is a launcher application, similar to macOS's built in Spotlight service. It does not surface Orion profile-apps, because they are stored several directories deep. Raycast does not recursively search folders for applications.

This proposed change adds instructions for how to manually add these folders for Raycast to index.