### PR TITLE
Add sortable tables

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from 'vitepress'
 import { SearchPlugin } from 'kagi-sidekick-vitepress'
+import { tableSort } from './custom_scripts/sort'
 
 // https://vitepress.dev/reference/site-config
 export default defineConfig({
@@ -12,6 +13,11 @@ export default defineConfig({
         ['link', { rel: "mask-icon", href: "/safari-pinned-tab.svg", color: "#5bbad5" }],
         ['meta', { name: "msapplication-TileColor", content: "#ffffff" }],
     ],
+    markdown: {
+      config: (md) => {
+        md.use(tableSort)
+      },
+    },
     themeConfig: {
         // https://vitepress.dev/reference/default-theme-config
         nav: [

--- a/docs/.vitepress/custom_scripts/sort.js
+++ b/docs/.vitepress/custom_scripts/sort.js
@@ -1,0 +1,70 @@
+export function tableSort(md) {
+  // Store the original table renderer for "table_open"
+  const originalTableOpen =
+    md.renderer.rules.table_open ||
+    function (tokens, idx, options, env, self) {
+      return self.renderToken(tokens, idx, options);
+    };
+
+  // Override "table_open" to add a sortable class and unique ID
+  md.renderer.rules.table_open = function (tokens, idx, options, env, self) {
+    tokens[idx].attrSet("id", `sortable-table-${idx}`);
+    tokens[idx].attrSet("class", "sortable-table");
+    return originalTableOpen(tokens, idx, options, env, self);
+  };
+}
+
+export function handleSort() {
+  if (typeof window !== "undefined") {
+    function sortTable(table, col, asc) {
+      const direction = asc ? 1 : -1;
+      const tbody = table.querySelector("tbody");
+      const rows = Array.from(tbody.querySelectorAll("tr"));
+
+      // Sort rows
+      const sortedRows = rows.sort((a, b) => {
+        const aCol = a
+          .querySelector(`td:nth-child(${col + 1})`)
+          .textContent.trim();
+        const bCol = b
+          .querySelector(`td:nth-child(${col + 1})`)
+          .textContent.trim();
+
+        // Try numeric sort first
+        const aNum = parseFloat(aCol);
+        const bNum = parseFloat(bCol);
+        if (!isNaN(aNum) && !isNaN(bNum)) {
+          return direction * (aNum - bNum);
+        }
+
+        // Fall back to string sort
+        return direction * aCol.localeCompare(bCol);
+      });
+
+      // Clear and append sorted rows
+      while (tbody.firstChild) {
+        tbody.removeChild(tbody.firstChild);
+      }
+      sortedRows.forEach((row) => tbody.appendChild(row));
+    }
+
+    // Attach click handlers to make any table with class "sortable-table" interactive
+    document.addEventListener("DOMContentLoaded", () => {
+      setTimeout(() => {
+        document.querySelectorAll(".sortable-table").forEach((table) => {
+          const headers = table.querySelectorAll("th");
+          headers.forEach((header, index) => {
+            header.addEventListener("click", () => {
+              // Toggle sort direction on each click
+              const asc = header.getAttribute("data-sort-asc") === "true";
+              const newAsc = !asc;
+              headers.forEach((h) => h.removeAttribute("data-sort-asc"));
+              header.setAttribute("data-sort-asc", newAsc);
+              sortTable(table, index, newAsc);
+            });
+          });
+        });
+      });
+    });
+  }
+}

--- a/docs/.vitepress/theme/custom.scss
+++ b/docs/.vitepress/theme/custom.scss
@@ -1,2 +1,15 @@
 @import "theme";
 @import "custom_code";
+
+.sortable-table {
+  th {
+    cursor: pointer;
+  }
+  th[data-sort-asc="true"]::after {
+    content: " ↑";
+  }
+
+  th[data-sort-asc="false"]::after {
+    content: " ↓";
+  }
+}

--- a/docs/.vitepress/theme/index.js
+++ b/docs/.vitepress/theme/index.js
@@ -1,5 +1,6 @@
 import DefaultTheme from "vitepress/theme";
 import queryHack from "../custom_scripts/search_query_hack";
+import { handleSort } from "../custom_scripts/sort";
 import { onMounted, watch, nextTick } from 'vue';
 import { useRoute } from 'vitepress';
 import mediumZoom from 'medium-zoom';
@@ -9,6 +10,7 @@ export default {
   ...DefaultTheme,
   enhanceApp({ app }) {
     queryHack();
+    handleSort();
   },
   setup() {
     const route = useRoute();


### PR DESCRIPTION
# Products Updated

Check all that apply:

- [x] Kagi Search Docs
- [x] Kagi Developer Docs

## Description

My initial attempt to add sortable tables support to all the tables in the documentation.

The tables look the same initially, but on click an arrow appears and the column
content is sorted in ascending or descending order.

Feedback or any improvements are welcome.

It definitely needs more testing for any edge cases.