### PR TITLE
added example of an assistant url with various options

### DIFF
--- a/docs/kagi/ai/assistant.md
+++ b/docs/kagi/ai/assistant.md
@@ -186,6 +186,9 @@ The `internet` parameter can be used to turn on and off internet access, set to 
 
 The `lens` parameter can be used to set the lens if internet access is enabled. The value of this is the lowercase format of the lens name, for example, `https://kagi.com/assistant?lens=programming&q=%s` will use the Programming lens.
 
+Here is an example of a URL that disables internet access, uses the **Claude 3 Haiku** model, and applies the **Programming lens**:  
+```https://kagi.com/assistant?profile=claude-3-haiku&internet=false&lens=programming&q=%s```
+
 ## Availability
 
 The Assistant is available to all Kagi Ultimate members.


### PR DESCRIPTION
# Products Updated

Check all that apply:

- [x] Kagi Search Docs 
- [ ] Kagi Developer Docs

## Description

I realized that there is not actually a proper example of a url with various parameters set, so adding this might help those who don't know how urls params work