### PR TITLE
Added comment to two pages that share content (in a way)

### DIFF
--- a/docs/kagi/ai/assistant.md
+++ b/docs/kagi/ai/assistant.md
@@ -159,6 +159,7 @@ The Assistant provides access to the following LLMs:
 | Amazon  | [Nova Lite](https://kagi.com/assistant?profile=nova-lite)        |
 | Amazon  | [Nova Pro](https://kagi.com/assistant?profile=nova-pro)         |
 
+<!-- NOTE: The LLM's listed here should match the bolded LLM's in the table at [LLM Pricing comparison](./llm-benchmark.md#llm-pricing-comparison) -->
 
 You can learn more about how these models compare in the [Kagi LLM Benchmarking Project](./llm-benchmark.md) page.
 

--- a/docs/kagi/ai/llm-benchmark.md
+++ b/docs/kagi/ai/llm-benchmark.md
@@ -93,7 +93,7 @@ The table below is updated to the best of our abilities, feel free to submit cha
 | **GPT-4 (32k)**                    | 32K            | 60                    | 120                    |
 | **GPT-3.5-Turbo**                  | 16K            | 0.5                   | 1.5                    |
 | **Claude 3 Haiku**                 | 200K           | 0.25                  | 1.25                   |
-| Claude 3.5 Haiku                   | 200K           | 1                     | 5                      |
+| Claude 3.5 Haiku      | 200K           | 1                     | 5                      |
 | **Claude 3.5 Sonnet**              | 200K           | 3                     | 15                     |
 | **Claude 3 Opus**                  | 200K           | 15                    | 75                     |
 | **Gemini 1.5 Pro** (128K/1M)       | 1M             | 3.50/7                | 10.50/21               |
@@ -114,6 +114,8 @@ The table below is updated to the best of our abilities, feel free to submit cha
 | x-ai/grok-2                    | 32K            | 5.0                   | 10.0                   |
 | nousresearch/hermes-3-llama-3.1-405b:free | 8K             | 0.0                   | 0.0                    |
 | liquid/lfm-40b                 | 32K            | 0.0                   | 0.0                    |
+
+<!-- NOTE: the bolded LLM's in this table should match [LLMs Available in The Assistant](./assistant.md#llms-available-in-the-assistant) -->
 
 [Kagi Assistant](./assistant.md) provides access to all the models in bold. Usage is included in your Kagi subscription.
 


### PR DESCRIPTION
# Products Updated

Check all that apply:

- [x] Kagi Search Docs 

## Description

Added a small notice to LLM benchmark page and assistant page, so that any time someone makes a change there, they're reminded to change it in the other location as well. doesn't render.

I would like to update the pricing table and add the other llm's but I don't know the source of the pricing. stuck on: https://github.com/kagisearch/kagi-docs/issues/637#:~:text=%20it's%20not%20clear%20what%20the%20origin%20of%20the%20prices%20is%20for%20the%20various%20open%20source%20models.%20i%20assume%20it's%20fireworks.ai%20pricing%20but%20it's%20not%20specified.