### PR TITLE
Add a new /kagi/privacy/tor page with Tor docs

### DIFF
--- a/docs/kagi/privacy/privacy-pass.md
+++ b/docs/kagi/privacy/privacy-pass.md
@@ -34,7 +34,9 @@ Select your browser for set up instructions:
 
 <video src="./media/kagi_privacy_pass_firefox.mp4" width="720" type="video/mp4" autoplay muted loop playsinline disablepictureinpicture />
 
-**Note for Tor users:** Currently Privacy Pass is only supported via the kagi.com domain name, support for our Onion address will be added in a future update.
+::: warning Note for Tor users
+Currently Privacy Pass is only supported via the kagi.com domain name, support for our Onion address will be added in a future update.
+:::
 </details>
 
 <details>

--- a/docs/kagi/privacy/tor.md
+++ b/docs/kagi/privacy/tor.md
@@ -1,0 +1,19 @@
+# Using Kagi with Tor
+
+The [Tor Project](https://www.torproject.org/) is a set of tools for preserving your privacy online, by routing your internet traffic through multiple volunteer-run relays. The main way to use Tor is through [the Tor Browser](https://www.torproject.org/download/).
+
+Kagi provides an official Tor onion service, which allows access to Kagi directly from the Tor network. Kagi's onion address is:
+
+[kagi2pv5bdcxxqla5itjzje2cgdccuwept5ub6patvmvn3qgmgjd6vid.onion](http://kagi2pv5bdcxxqla5itjzje2cgdccuwept5ub6patvmvn3qgmgjd6vid.onion)
+
+# Using Tor with Privacy Pass
+
+::: warning Note for Tor users
+Currently Privacy Pass is only supported via the kagi.com domain name, support for our Onion address will be added in a future update.
+:::
+
+On its own, Tor will obscure your location by hiding your IP address, which can be useful for preventing your ISP or site providers from tracking you. This isn't particularly useful when using Kagi, since you'd still normally have to be logged into your account, making all your searches theoretically linkable back to a single account.
+
+This is where [Privacy Pass](./privacy-pass.md) comes in: with Tor and Privacy Pass together, Kagi only knows that the search is being issued by a user who previously verified that they have an account authorized to receive tokens, but nothing about the user's account, or where they're located. Follow [the Firefox / Tor Browser instructions](./privacy-pass.html#getting-started) in our Getting Started guide to set up Privacy Pass with the Tor Browser.
+
+As always, Kagi does not link searches to accounts or permanently record them; see [our Privacy Policy](https://kagi.com/privacy) for more info.

--- a/docs/kagi/privacy/tor.md
+++ b/docs/kagi/privacy/tor.md
@@ -1,6 +1,6 @@
 # Using Kagi with Tor
 
-The [Tor Project](https://www.torproject.org/) is a set of tools for preserving your privacy online, by routing your internet traffic through multiple volunteer-run relays. The main way to use Tor is through [the Tor Browser](https://www.torproject.org/download/).
+The [Tor Project](https://www.torproject.org/) is a set of tools for preserving your privacy and anonymity online, by routing your internet traffic through multiple volunteer-run relays. The main way to use Tor is through [the Tor Browser](https://www.torproject.org/download/).
 
 Kagi provides an official Tor onion service, which allows access to Kagi directly from the Tor network. Kagi's onion address is:
 


### PR DESCRIPTION
Advertises our new Tor endpoint, as well as how to integrate with Privacy Pass