### PR TITLE
Replace Orion for iOS Privacy Pass image with a video

### DIFF
--- a/docs/kagi/privacy/privacy-pass.md
+++ b/docs/kagi/privacy/privacy-pass.md
@@ -40,7 +40,7 @@ Select your browser for set up instructions:
 2. Tap the three dots at the bottom right corner and select **Kagi Privacy Pass**.
 3. Make sure **Authenticate via Privacy Pass** is enabled.
 
-![Kagi Privacy Pass - Orion for iPhone](./media/kagi_privacy_pass_orion_ios.png){width=700px data-zoomable}
+<video src="./media/kagi_privacy_pass_orion_ios.mp4" width="720" type="video/mp4" autoplay muted loop playsinline disablepictureinpicture />
 
 </details>
 


### PR DESCRIPTION
Replace Orion for iOS Privacy Pass image with a video