### PR TITLE
update docs to reflect lifetime sub option; WIP Linux port

### DIFF
--- a/docs/orion/orion-plus/orion-plus.md
+++ b/docs/orion/orion-plus/orion-plus.md
@@ -1,6 +1,8 @@
 # What is Orion+?
 
-[Orion+](https://browser.kagi.com/orionplus.html) allows you to support the Orion project and mission. For a small fee ($5 per month or $50 per year), you’ll get:
+[Orion+](https://browser.kagi.com/orionplus.html) allows you to support the Orion project and mission.
+
+For a small fee ($5 per month, $50 per year, or $150 for a lifetime subscription), you’ll get:
 
 - Direct communication with the development team
 - The ability to influence the browser’s development
@@ -10,4 +12,4 @@
 
 We are still working on some of these features and they will be released shortly.
 
-Your financial contribution will help us to stay independent and to deliver on our promise of becoming the best browser for Apple users. You can also help us by spreading the word about Orion everywhere you go, from social media to the dinner table.
+Your financial contribution will help us to stay independent and to deliver on our promise of becoming the best browser for our users. You can also help us by spreading the word about Orion everywhere you go, from social media to the dinner table.


### PR DESCRIPTION
I just did some very minor editing to keep https://help.kagi.com/orion/orion-plus/orion-plus.html up-to-date;

- Mention the $150 / lifetime subscription option
- Remove the explicit reference to "Apple users" given the recently-announced WIP Linux port