### PR TITLE
Update link to open a pull request for new community addons

### DIFF
--- a/docs/kagi/community-addons/index.md
+++ b/docs/kagi/community-addons/index.md
@@ -3,7 +3,7 @@
 Members of the Kagi community have brought Kagi to their favorite tools!
 You can find a list below of integrations that our users have contributed to other products, or built themselves.
 
-If you created or found a Kagi integration with other products or tools, we would happily welcome a [pull request to this page](https://github.com/kagisearch/kagi-docs/edit/main/kagi/src/support-and-community/open-source.md)!
+If you created or found a Kagi integration with other products or tools, we would happily welcome a [pull request to this page](https://github.com/kagisearch/kagi-docs/edit/main/docs/kagi/community-addons/index.md)!
 
 ## Raycast
 


### PR DESCRIPTION
Looks like the file had moved, making the link to open a PR from the [Community Add-ons page](https://help.kagi.com/kagi/community-addons/) incorrect. I updated the link to the new location, and confirmed the link is correct by using it to make this PR [insert inception GIF here].