### PR TITLE
Add link to unofficial kagi-translate webextension to index.md

### DIFF
--- a/docs/kagi/community-addons/index.md
+++ b/docs/kagi/community-addons/index.md
@@ -65,3 +65,7 @@ Adds a button to the right click context menu on Firefox that allows you to open
 ## 3rd party apps
 
 - [Lensai](https://github.com/FaFre/lensai) browser has **[Kagi Integration](https://github.com/FaFre/lensai/wiki/Kagi-Tools)** integrating Kagi's search, assistant, and summarizer tools within a user-friendly interface.
+
+## Kagi Translate Extension
+
+- [Kagi Translate Extension](https://github.com/mosk-it/kagi-translate-ext) is webextension to translate selected text from selected languages in firefox and Chrome


### PR DESCRIPTION
hey, it's simple addon that allows to translate selected text on any page using kagi-translate, it's mainly for firefox, although I made it work with chrome too

any suggestions are appreciated