### PR TITLE
Added Kagi API gem to unofficial client libraries documentation

### DIFF
--- a/docs/kagi/api/overview.md
+++ b/docs/kagi/api/overview.md
@@ -37,6 +37,7 @@ Libraries created by Kagi users and third parties.
 
 - [kagigo for Go - FastGPT & Universal Summarizer](https://github.com/httpjamesm/kagigo)
 - [kagi-api](https://crates.io/crates/kagi-api) for Rust
+- [kagi-api](https://alchemists.io/projects/kagi-api) for Ruby
 - [kagi-dotnet](https://github.com/patchoulish/kagi-dotnet) for C#/.NET
 
 ## Beta Status


### PR DESCRIPTION
## Overview

Hello. :wave: This provides a link to the Kagi API gem for anyone using Ruby that might want this. This is related to the forum discussion posted [here](https://kagifeedback.org/d/7021-add-ruby-api-client).

*Please note that I link to my site documentation rather than GitHub since my site documentation surpases anything GitHub can do which includes build badges and full access to release notes*.
