### PR TITLE
Remove note about Kagi Assistant being only available in Ultimate

### DIFF
--- a/docs/kagi/features/bangs.md
+++ b/docs/kagi/features/bangs.md
@@ -116,8 +116,6 @@ zm   | Zambia
 
 ### The Assistant bangs
 
-> **Note:** The Assistant is available in our Ultimate plan.
-
 You can quickly access Assistant from Kagi Search by using the following bangs:
 `!ai`, `!chat`, `!assistant` , `!llm`, `!asst`, `!as`, `!expert` and `!fast`
 


### PR DESCRIPTION
Remove note about Kagi Assistant being only available in Ultimate