### PR TITLE
Documentation link fixes

### DIFF
--- a/docs/kagi/ai/llm-benchmark.md
+++ b/docs/kagi/ai/llm-benchmark.md
@@ -1,10 +1,10 @@
 # Kagi LLM Benchmarking Project
 
-Introducing the Kagi LLM Benchmarking Project, which evaluates major large language models (LLMs) on their reasoning, coding, and instruction following capabilities.
+Introducing the Kagi LLM Benchmarking Project, which evaluates major large language models (LLMs) on their reasoning, coding, and instruction-following capabilities.
 
 ## Kagi Reasoning Benchmark
 
-The Kagi Reasoning Benchmark is an **unpolluted reasoning benchmark** to assess large language models (LLMs) through diverse, challenging tasks. Unlike standard benchmarks, the tasks in this benchmark are unpublished, not to be found in training data or "gamed" in finetuning. The task set changes over time (mostly getting more difficult) to better represent current state of the art.
+The Kagi Reasoning Benchmark is an **unpolluted reasoning benchmark** to assess large language models (LLMs) through diverse, challenging tasks. Unlike standard benchmarks, the tasks in this benchmark are unpublished, not found in training data, or "gamed" in fine-tuning. The task set changes over time (mostly getting more difficult) to better represent the current state of the art.
 
 Last update: **May 28th, 2025**
 
@@ -84,11 +84,11 @@ Input Tokens for all tasks: **10859**
 
 **Model Costs:** Costs in the reasoning benchmark are mostly from the models' output tokens. **This table's cost column is not representative for input token heavy tasks like web search or retrieval.**
 
-**CoT Tags:** Models that use [reasoning or chain-of-thought](https://en.wikipedia.org/wiki/Prompt_engineering#Chain-of-thought) are denoted by the `[CoT]` tag. The `CoT` models produce extra tokens pondering before giving a final answer. This generally produce better results on reasoning benchmarks, at the expense of speed, and the cost of additional tokens.
+**CoT Tags:** Models that use [reasoning or chain-of-thought](https://en.wikipedia.org/wiki/Prompt_engineering#Chain-of-thought) are denoted by the `[CoT]` tag. The `CoT` models produce extra tokens pondering before giving a final answer. This generally produces better results on reasoning benchmarks, at the expense of speed and the cost of additional tokens.
 
 For example, `grok-3-mini` uses chain of thought and `grok-3` does not. This is why `grok-3-mini` outperforms its bigger sibling in this benchmark.
 
-Reasoning models may not be the best choice for all tasks! Pick the model that does the best at what you intend to do. We will be including other benchmark tables (search, tool use, agentic task completion) shortly.
+Reasoning models may not be the best choice for all tasks! Pick the model that performs best at what you intend to do. We will be including other benchmark tables (search, tool use, agentic task completion) shortly.
 
 # Benchmark Questions
 

--- a/docs/kagi/getting-started/setting-default/chromium-desktop.md
+++ b/docs/kagi/getting-started/setting-default/chromium-desktop.md
@@ -26,7 +26,7 @@ To enhance your browsing experience with Kagi, follow these steps to set Kagi as
 2. In the **Site Search** section about halfway down, click the **Add** button at its upper right and fill in these details:
 	- **Search engine:** Kagi Search
 	- **Keyword:** kagi
-	- **Query URL:** `https://kagi.com/search?q=%s` if you're not planning to use Kagi in private search. If you are, then use `https://kagi.com/search?token=TOKEN&q=%s` (replace TOKEN with the token found in your [private session link​](#private_session))
+	- **Query URL:** `https://kagi.com/search?q=%s` if you're not planning to use Kagi in private search. If you are, then use `https://kagi.com/search?token=TOKEN&q=%s` (replace TOKEN with the token found in your [private session link​](./../../privacy/private-browser-sessions))
 3. Find Kagi again in the Site Search section. You may have to click **Additional sites** at the bottom if you don't see it right away.
 3. Click the three dots next to the Kagi entry in the list.
 4. Click **Make default**.

--- a/docs/kagi/getting-started/setting-default/firefox-desktop.md
+++ b/docs/kagi/getting-started/setting-default/firefox-desktop.md
@@ -22,7 +22,7 @@ To set up a private session link in Firefox:
 4. Click the "Add" button below the table under the heading "Search Shortcuts"
 5. Enter the following values:
 	- **Search engine name:** `Kagi Search`
-	- **Engine URL:** `https://kagi.com/search?token=TOKEN&q=%s` (replace TOKEN with the token found in your [private session link​](#private_session))
+	- **Engine URL:** `https://kagi.com/search?token=TOKEN&q=%s` (replace TOKEN with the token found in your [private session link​](./../../privacy/private-browser-sessions))
 	- **Alias:** `kagi`
 6. Select the new "Kagi Search" as your default search engine using the dropdown at the top of this page.
 


### PR DESCRIPTION
- Fix private session documentation links in Chromium and Firefox instructions. 
- Minor grammatical tweaks to LLM benchmark page.