### PR TITLE
Added link to CSS snippet to hide AI features

### DIFF
--- a/docs/kagi/features/custom-css.md
+++ b/docs/kagi/features/custom-css.md
@@ -413,6 +413,12 @@ Hide the floating Quick Search button from Kagi search results page.
 
 </details>
 
+<details><summary>Hide AI features</summary>
+
+[**Get it**](https://codeberg.org/zerodogg/kagi-no-ai#readme)
+
+</details>
+
 ## Learn
 
 If you want to learn more about how to customize your Kagi Search CSS, below is a video tutorial. The video features a slightly older design of Kagi Search, but the CSS principles are the same.


### PR DESCRIPTION
This is a workaround for [kagi suggestion 4014](https://kagifeedback.org/d/4014-option-to-turn-off-all-ai-features). It simply hides all the AI features.

I've placed the snippet in the public domain, so it could be embedded instead, but linking makes it easier to update if I find something I've missed.