### PR TITLE
Update benchmark results to add Grok 4, Kimi K2, and misc. models

### DIFF
--- a/docs/kagi/ai/llm-benchmark.md
+++ b/docs/kagi/ai/llm-benchmark.md
@@ -6,7 +6,7 @@ Introducing the Kagi LLM Benchmarking Project, which evaluates major large langu
 
 The Kagi Reasoning Benchmark is an **unpolluted reasoning benchmark** to assess large language models (LLMs) through diverse, challenging tasks. Unlike standard benchmarks, the tasks in this benchmark are unpublished, not found in training data, or "gamed" in fine-tuning. The task set changes over time (mostly getting more difficult) to better represent the current state of the art.
 
-Last update: **May 28th, 2025**
+Last update: **July 16th, 2025**
 
 Tasks: **100**
 
@@ -14,69 +14,76 @@ Input Tokens for all tasks: **10859**
 
 <div class="minimal-table-margins">
 
-| model                         |   accuracy (%) |   time_per_task |   cost | output_tokens| tok/s  | provider            |
-|-------------------------------|----------------|-----------------|--------|--------------|--------|---------------------|
-| o3 `[CoT]`                    |          78.03 |            1.08 |   2.08 | 6.2k         |   9.25 | kagi (ultimate)     |
-| claude-4-opus `[CoT]`         |          77.46 |            3.25 |   2.84 | 8.4k         |   9.05 | kagi (ultimate)     |
-| gemini-2-5-pro `[CoT]`        |          74.03 |            0.94 |   0.19 | 6.9k         |   9.51 | kagi (ultimate)     |
-| arcee-ai/maestro `[CoT]`      |          72.92 |          105.49 |   0.25 | 170k         |   2.86 | together            |
-| qwen-3-235b-a22b-rope `[CoT]` |          72.12 |           58.65 |   0.08 | 120k         |   3.61 | kagi (ultimate)     |
-| o1 `[CoT]`                    |          71.73 |            8.49 |   5.11 | 4k           |   3.30 | Depr. (o3)          |
-| o1-pro `[CoT]`                |          70.92 |           19.90 |  47.64 | 3.8k         |   0.97 | Depr. (o3)          |
-| claude-4-sonnet `[CoT]`       |          68.69 |            2.03 |   0.62 | 8.9k         |  14.38 | kagi (ultimate)     |
-| o4-mini `[CoT]`               |          67.79 |           -     |   0.32 | 4.4k         |  -     | kagi (ultimate)     |
-| claude-3-7-sonnet `[CoT]`     |          65.15 |           -     |   1.81 | 110k         |  -     | Depr. (claude-4)    |
-| qwen-qwq-32b `[CoT]`          |          64.60 |           -     |   0.87 | 520k         |  -     | Depr. (qwen3-235b)  |
-| deepseek-r1 `[CoT]`           |          64.00 |           -     |   0.97 | 110k         |  -     | kagi (ultimate)     |
-| o3-mini `[CoT]`               |          63.37 |           -     |   0.42 | 11k          |  -     | Depr. (o4-mini)     |
-| grok-3-mini `[CoT-high]`      |          62.58 |            1.51 |   0.28 | 12k          |   9.77 | xai                 |
-| qwen-3-235b-a22b `[CoT]`      |          61.03 |            8.44 |   0.06 | 9k           |   3.34 | Nebius              |
-| grok-3-mini `[CoT-low]`       |          60.76 |            1.04 |   0.02 | 4.9k         |   8.16 | kagi (all)          |
-| claude-4-opus [no-think]      |          60.21 |            1.27 |   1.06 | 9.1k         |  24.66 | kagi (ultimate)     |
-| perplexity/sonar-pro `[CoT]`  |          55.21 |            0.46 |   0.11 | 12k          |  66.52 | perplexity          |
-| chatgpt-4o                    |          54.80 |           -     |   0.57 | 18k          |  -     | kagi (ultimate)     |
-| gpt-4-1                       |          53.76 |           -     |   0.18 | 17k          |  -     | kagi (ultimate)     |
-| deepseekr1-distil-llama`[CoT]`|          52.62 |           -     |   0.33 | 110k         |  -     | kagi (ultimate)     |
-| claude-4-sonnet [no-think]    |          52.58 |            0.93 |   0.23 | 10k          |  37.39 | kagi (ultimate)     |
-| deepseek-chat-v3              |          51.95 |           -     |   0.24 | 21k          |  -     | kagi (all)          |
-| qwen-3-32b `[CoT]`            |          49.83 |            3.26 |   0.03 | 9.8k         |  10.24 | kagi (ultimate)     |
-| thedrummer/anubis-pro-105b-v1 |          48.96 |            7.96 |   0.02 | 14k          |   3.10 | openrouter          |
-| llama-4-maverick              |          48.93 |           -     |   0.03 | 20k          |  -     | kagi (all)          |
-| gpt-4-1-mini                  |          48.80 |           -     |   0.05 | 23k          |  -     | kagi (all)          |
-| grok-3                        |          48.40 |           -     |   0.70 | 16k          |  -     | kagi (ultimate)     |
-| mistral-medium                |          47.20 |            0.68 |   0.05 | 12k          |  53.31 | kagi (all)          |
-| Qwen3-4B `[CoT]`              |          43.95 |           13.39 |  -     | 19k          |   4.54 | nebius              |
-| qwen-3-235b-a22b [no-think]   |          43.00 |            3.17 |   0.02 | 18k          |  19.25 | kagi (all)          |
-| gpt-4o                        |          42.60 |           -     |   0.22 | 12k          |  -     | kagi (ultimate)     |
-| gemini-2-5-flash [no-think]   |          41.88 |            0.37 |   0.02 | 11k          |  51.54 | kagi (all)          |
-| mistral-large                 |          40.53 |           -     |   0.10 | 12k          |  -     | kagi (ultimate)     |
-| claude-3-5-sonnet             |          38.89 |           -     |   0.23 | 10k          |  -     | Depr. (claude-4)    |
-| mistral-small                 |          37.99 |           -     |   0.00 | 12k          |  -     | kagi (all)          |
-| aion-labs/aion-1.0-mini       |          37.20 |            0.87 |   0.08 | 46k          | 124.56 | openrouter          |
-| claude-3-opus                 |          37.09 |           -     |   1.29 | 9.8k         |  -     | Depr. (claude-4)    |
-| llama-3-405b                  |          37.07 |           -     |   0.27 | 30k          |  -     | Depr. (llama-4)     |
-| minimax/minimax-01            |          36.40 |            0.84 |   0.02 | 15k          |  19.37 | openrouter          |
-| arcee-ai/virtuoso-large       |          35.42 |            1.69 |   0.02 | 12k          |  12.56 | together            |
-| gpt-4-turbo                   |          34.27 |           -     |   1.09 | 16k          |  -     | Depr. (gpt-4-1)     |
-| gemini-flash                  |          34.10 |            0.39 |   0.01 | 6.4k         |  31.45 | kagi (all)          |
-| qwen-3-32b [no-think]         |          33.93 |            6.34 |   0.02 | 33k          |  15.62 | kagi (all)          |
-| gpt-4                         |          33.44 |           -     |   2.22 | 7.2k         |  -     | Depr. (gpt-4-1)     |
-| gpt-4o-mini                   |          33.38 |           -     |   0.02 | 29k          |  -     | kagi (all)          |
-| claude-3-opus                 |          31.23 |            1.55 |   1.06 | 8.7k         |  17.75 | Depr. (claude-4)    |
-| gemini-1-5-pro                |          31.20 |           -     |   0.38 | 5.9k         |  -     | Depr. (gemini-2-5)  |
-| llama-4-scout                 |          30.80 |           -     |   0.02 | 17k          |  -     | kagi (all)          |
-| llama-3-70b                   |          29.21 |            0.97 |   0.06 | 11k          |  34.37 | Depr. (llama-4)     |
-| qwen-2-5-vl-72b               |          28.36 |            2.41 |   0.01 | 8.4k         |  10.43 | Nebius              |
-| claude-3-haiku                |          26.44 |           -     |   0.09 | 8.6k         |  -     | kagi (ultimate)     |
-| qwen-vl-max                   |          25.31 |            1.18 |   0.06 | 7.4k         |  19.54 | Depr. (qwen-3)      |
-| nova-pro                      |          23.63 |           -     |   0.13 | 24k          |  -     | Depr: uncompetitive |
-| llama-3-3b                    |          22.79 |            2.37 |   0.01 | 19k          |  27.85 | openrouter          |
-| mistral-nemo                  |          22.40 |           -     |   0.00 | 10k          |  -     | Depr. (small-3.1)   |
-| gemma-3-27b                   |          21.79 |            1.32 |   0.01 | 15k          |  39.82 | Nebius              |
-| nova-lite                     |          21.04 |           -     |   0.01 | 19k          |  -     | Depr: uncompetitive |
-| cohere/command-r7b-12-2024    |          19.82 |            2.96 |   0.00 | 13k          |   6.85 | openrouter          |
-| gemma2-9b-it                  |          19.27 |            0.77 |  -     | 6k           |  13.69 | groq                |
-| liquid/lfm-40b                |          17.71 |            5.81 |   0.00 | 12k          |   3.67 | openrouter          |
+| model                                  | accuracy (%) | time_per_task | cost  | output_tokens | tok/s  | provider            |
+| -------------------------------------- | ------------ | ------------- | ----- | ------------- | ------ | ------------------- |
+| o3 `[CoT]`                             | 78.03        | 1.08          | 2.08  | 6.2k          | 9.25   | kagi (ultimate)     |
+| claude-4-opus `[CoT]`                  | 77.46        | 3.25          | 2.84  | 8.4k          | 9.05   | kagi (ultimate)     |
+| gemini-2-5-pro `[CoT]`                 | 74.03        | 0.94          | 0.19  | 6.9k          | 9.51   | kagi (ultimate)     |
+| arcee-ai/maestro `[CoT]`               | 72.92        | 105.49        | 0.25  | 170k          | 2.86   | together            |
+| qwen-3-235b-a22b-rope `[CoT]`          | 72.12        | 58.65         | 0.08  | 120k          | 3.61   | kagi (ultimate)     |
+| o1 `[CoT]`                             | 71.73        | 8.49          | 5.11  | 4k            | 3.30   | Depr. (o3)          |
+| o1-pro `[CoT]`                         | 70.92        | 19.90         | 47.64 | 3.8k          | 0.97   | Depr. (o3)          |
+| claude-4-sonnet `[CoT]`                | 68.69        | 2.03          | 0.62  | 8.9k          | 14.38  | kagi (ultimate)     |
+| o4-mini `[CoT]`                        | 67.79        | -             | 0.32  | 4.4k          | -      | kagi (ultimate)     |
+| claude-3-7-sonnet `[CoT]`              | 65.15        | -             | 1.81  | 110k          | -      | Depr. (claude-4)    |
+| qwen-qwq-32b `[CoT]`                   | 64.60        | -             | 0.87  | 520k          | -      | Depr. (qwen3-235b)  |
+| grok-4 `[CoT]`                         | 64.31        | 98.80         | 1.96  | 9.7k          | 0.67   | kagi (ultimate)     |
+| deepseek-r1 `[CoT]`                    | 64.00        | -             | 0.97  | 110k          | -      | kagi (ultimate)     |
+| o3-mini `[CoT]`                        | 63.37        | -             | 0.42  | 11k           | -      | Depr. (o4-mini)     |
+| grok-3-mini `[CoT-high]`               | 62.58        | 1.51          | 0.28  | 12k           | 9.77   | xai                 |
+| qwen-3-235b-a22b `[CoT]`               | 61.03        | 8.44          | 0.06  | 9k            | 3.34   | Nebius              |
+| grok-3-mini `[CoT-low]`                | 60.76        | 1.04          | 0.02  | 4.9k          | 8.16   | kagi (all)          |
+| claude-4-opus [no-think]               | 60.21        | 1.27          | 1.06  | 9.1k          | 24.66  | kagi (ultimate)     |
+| perplexity/sonar-pro `[CoT]`           | 55.21        | 0.46          | 0.11  | 12k           | 66.52  | perplexity          |
+| chatgpt-4o                             | 54.80        | -             | 0.57  | 18k           | -      | kagi (ultimate)     |
+| gpt-4-1                                | 53.76        | -             | 0.18  | 17k           | -      | kagi (ultimate)     |
+| deepseekr1-distil-llama`[CoT]`         | 52.62        | -             | 0.33  | 110k          | -      | kagi (ultimate)     |
+| claude-4-sonnet [no-think]             | 52.58        | 0.93          | 0.23  | 10k           | 37.39  | kagi (ultimate)     |
+| deepseek-chat-v3                       | 51.95        | -             | 0.24  | 21k           | -      | kagi (all)          |
+| qwen-3-32b `[CoT]`                     | 49.83        | 3.26          | 0.03  | 9.8k          | 10.24  | kagi (ultimate)     |
+| thedrummer/anubis-pro-105b-v1          | 48.96        | 7.96          | 0.02  | 14k           | 3.10   | openrouter          |
+| llama-4-maverick                       | 48.93        | -             | 0.03  | 20k           | -      | kagi (all)          |
+| gpt-4-1-mini                           | 48.80        | -             | 0.05  | 23k           | -      | kagi (all)          |
+| grok-3                                 | 48.40        | -             | 0.70  | 16k           | -      | kagi (ultimate)     |
+| kimi-k2                                | 47.81        | 12.97         | 1.58  | 80k           | 41.19  | kagi (ultimate)     |
+| mistral-medium                         | 47.20        | 0.68          | 0.05  | 12k           | 53.31  | kagi (all)          |
+| Qwen3-4B `[CoT]`                       | 43.95        | 13.39         | -     | 19k           | 4.54   | nebius              |
+| qwen-3-235b-a22b [no-think]            | 43.00        | 3.17          | 0.02  | 18k           | 19.25  | kagi (all)          |
+| gpt-4o                                 | 42.60        | -             | 0.22  | 12k           | -      | kagi (ultimate)     |
+| gemini-2-5-flash [no-think]            | 41.88        | 0.37          | 0.02  | 11k           | 51.54  | kagi (all)          |
+| mistral-large                          | 40.53        | -             | 0.10  | 12k           | -      | kagi (ultimate)     |
+| claude-3-5-sonnet                      | 38.89        | -             | 0.23  | 10k           | -      | Depr. (claude-4)    |
+| mistral-small                          | 37.99        | -             | 0.00  | 12k           | -      | kagi (all)          |
+| aion-labs/aion-1.0-mini                | 37.20        | 0.87          | 0.08  | 46k           | 124.56 | openrouter          |
+| claude-3-opus                          | 37.09        | -             | 1.29  | 9.8k          | -      | Depr. (claude-4)    |
+| llama-3-405b                           | 37.07        | -             | 0.27  | 30k           | -      | Depr. (llama-4)     |
+| microsoft/phi-4-reasoning-plus `[CoT]` | 36.64        | 52.69         | 0.84  | 565k          | 71.89  | openrouter          |
+| baidu/ernie-4.5-300b-a47b              | 36.42        | 12.24         | 0.40  | 61k           | 33.52  | openrouter          |
+| minimax/minimax-01                     | 36.40        | 0.84          | 0.02  | 15k           | 19.37  | openrouter          |
+| arcee-ai/virtuoso-large                | 35.42        | 1.69          | 0.02  | 12k           | 12.56  | together            |
+| gpt-4-turbo                            | 34.27        | -             | 1.09  | 16k           | -      | Depr. (gpt-4-1)     |
+| gemini-flash                           | 34.10        | 0.39          | 0.01  | 6.4k          | 31.45  | kagi (all)          |
+| qwen-3-32b [no-think]                  | 33.93        | 6.34          | 0.02  | 33k           | 15.62  | kagi (all)          |
+| gpt-4                                  | 33.44        | -             | 2.22  | 7.2k          | -      | Depr. (gpt-4-1)     |
+| gpt-4o-mini                            | 33.38        | -             | 0.02  | 29k           | -      | kagi (all)          |
+| cohere/command-a                       | 32.26        | 5.91          | 2.02  | 33k           | 38.55  | openrouter          |
+| claude-3-opus                          | 31.23        | 1.55          | 1.06  | 8.7k          | 17.75  | Depr. (claude-4)    |
+| gemini-1-5-pro                         | 31.20        | -             | 0.38  | 5.9k          | -      | Depr. (gemini-2-5)  |
+| llama-4-scout                          | 30.80        | -             | 0.02  | 17k           | -      | kagi (all)          |
+| llama-3-70b                            | 29.21        | 0.97          | 0.06  | 11k           | 34.37  | Depr. (llama-4)     |
+| qwen-2-5-vl-72b                        | 28.36        | 2.41          | 0.01  | 8.4k          | 10.43  | Nebius              |
+| thedrummer/valkyrie-49b-v1             | 26.66        | 9.51          | 0.33  | 32k           | 22.36  | openrouter          |
+| claude-3-haiku                         | 26.44        | -             | 0.09  | 8.6k          | -      | kagi (ultimate)     |
+| qwen-vl-max                            | 25.31        | 1.18          | 0.06  | 7.4k          | 19.54  | Depr. (qwen-3)      |
+| nova-pro                               | 23.63        | -             | 0.13  | 24k           | -      | Depr: uncompetitive |
+| llama-3-3b                             | 22.79        | 2.37          | 0.01  | 19k           | 27.85  | openrouter          |
+| mistral-nemo                           | 22.40        | -             | 0.00  | 10k           | -      | Depr. (small-3.1)   |
+| gemma-3-27b                            | 21.79        | 1.32          | 0.01  | 15k           | 39.82  | Nebius              |
+| nova-lite                              | 21.04        | -             | 0.01  | 19k           | -      | Depr: uncompetitive |
+| cohere/command-r7b-12-2024             | 19.82        | 2.96          | 0.00  | 13k           | 6.85   | openrouter          |
+| gemma2-9b-it                           | 19.27        | 0.77          | -     | 6k            | 13.69  | groq                |
+| liquid/lfm-40b                         | 17.71        | 5.81          | 0.00  | 12k           | 3.67   | openrouter          |
+| microsoft/phi-4-multimodal-instruct    | 15.89        | 3.12          | 0.01  | 35k           | 75.79  | openrouter          |
 
 {.sortable}
 


### PR DESCRIPTION
Here are the raw results for the newly added models:
```
| model                               |   accuracy_avg |   accuracy_best |   n_tasks |   completed_tasks |   max_score |   mean_score |   consistency_index |   tot_score |   runs |   completed_runs |   cost |   time | provider   |   in_tokens |   out_tokens |   tot_time |   time_per_task |   cost_index |   speed_index |   tps |
|-------------------------------------|----------------|-----------------|-----------|-------------------|-------------|--------------|---------------------|-------------|--------|------------------|--------|--------|------------|-------------|--------------|------------|-----------------|--------------|---------------|-------|
| grok-4                              |          64.31 |           79.59 |       148 |               147 |         117 |        95.10 |                0.85 |         483 |    751 |             1.00 |   1.96 |  14525 | kagi       |    11029.00 |         9684 |   74200.38 |           98.80 |         0.33 |          0.00 |  0.67 |
| kimi-k2                             |          47.81 |           64.19 |       148 |               148 |          95 |        70.20 |                0.83 |         361 |    755 |             1.00 |   1.58 |   1933 | kagi       |    11029.00 |        79630 |    9789.45 |           12.97 |         0.30 |          0.02 | 41.19 |
| minimax/minimax-m1                  |          44.84 |           69.14 |       148 |                81 |          56 |        44.08 |                0.92 |         178 |    397 |             0.79 |   1.18 |   8644 | openrouter |    11029.00 |        10971 |   34532.32 |           86.98 |         0.38 |          0.01 |  1.27 |
| microsoft/phi-4-reasoning-plus      |          36.64 |           54.48 |       148 |               145 |          79 |        54.50 |                0.83 |         218 |    595 |             0.99 |   0.84 |   7865 | openrouter |    11029.00 |       565411 |   31349.29 |           52.69 |         0.43 |          0.00 | 71.89 |
| baidu/ernie-4.5-300b-a47b           |          36.42 |           51.35 |       148 |               148 |          76 |        53.62 |                0.85 |         220 |    604 |             1.00 |   0.40 |   1832 | openrouter |    11029.00 |        61410 |    7391.09 |           12.24 |         0.90 |          0.02 | 33.52 |
| cohere/command-a                    |          32.26 |           46.85 |       148 |               143 |          67 |        46.38 |                0.86 |         190 |    589 |             0.99 |   2.02 |    862 | openrouter |    11029.00 |        33236 |    3483.03 |            5.91 |         0.16 |          0.04 | 38.55 |
| thedrummer/valkyrie-49b-v1          |          26.66 |           40.54 |       148 |               148 |          60 |        40.25 |                0.87 |         161 |    604 |             1.00 |   0.33 |   1431 | openrouter |    11029.00 |        31999 |    5746.12 |            9.51 |         0.80 |          0.02 | 22.36 |
| cognitivecomputations/dolphin-mistr |          23.03 |           37.10 |       148 |                62 |          23 |        18.75 |                0.97 |          79 |    343 |             0.66 |   0.41 |    717 | openrouter |    11029.00 |        15991 |    2931.62 |            8.55 |         0.56 |          0.03 | 22.32 |
| microsoft/phi-4-multimodal-instruct |          15.89 |           26.35 |       148 |               148 |          39 |        23.00 |                0.89 |          96 |    604 |             1.00 |   0.01 |    466 | openrouter |    11029.00 |        35332 |    1884.38 |            3.12 |        20.17 |          0.03 | 75.79 |
```
Note that Minimax M1 and Dolphin Mistral 24B Venice Edition did not make it to the final table since we got too many empty output/rate limit errors, preventing them from completing at least 95 tasks