### PR TITLE
Further default engine fixes

### DIFF
--- a/docs/kagi/getting-started/setting-default.md
+++ b/docs/kagi/getting-started/setting-default.md
@@ -13,7 +13,7 @@ Choose your browser below for instructions:
 | **Edge** | **Brave** | **Vivaldi** | **Firefox Focus** |
 |---|---|---|---|
 | <img src="./setting-default/media/edge_icon.png"    alt="Edge"    width="96"> | <img src="./setting-default/media/brave_icon.png"   alt="Brave"   width="96"> | <img src="./setting-default/media/vivaldi_icon.png" alt="Vivaldi" width="96"> | <img src="./setting-default/media/firefox_focus_icon.png" alt="Firefox Focus" width="96"> |
-| [Desktop / Mac](./setting-default/chromium-desktop.md)<br>[iPhone / iPad](./setting-default/chromium-mobile.md)<br>[Android](./setting-default/chromium-mobile.md) | [Desktop / Mac](./setting-default/chromium-desktop.md)<br>[iPhone / iPad](./setting-default/chromium-mobile.md)<br>[Android](./setting-default/chromium-mobile.md) | [Desktop / Mac](./setting-default/vivaldi-desktop.md)<br>[iPhone / iPad](./setting-default/vivaldi-mobile.md)<br>[Android](./setting-default/vivaldi-mobile.md) | [iPhone / iPad](./setting-default/firefox-focus-iphone-ipad.md)<br>[Android](./setting-default/firefox-focus-android.md) |
+| [Desktop / Mac](./setting-default/chromium-desktop.md)<br>[iPhone / iPad](./setting-default/edge-ios.md)<br>[Android](./setting-default/chromium-mobile.md) | [Desktop / Mac](./setting-default/chromium-desktop.md)<br>[iPhone / iPad](./setting-default/brave-ios.md)<br>[Android](./setting-default/chromium-mobile.md) | [Desktop / Mac](./setting-default/vivaldi-desktop.md)<br>[iPhone / iPad](./setting-default/vivaldi-ios.md)<br>[Android](./setting-default/vivaldi-android.md) | [iPhone / iPad](./setting-default/firefox-focus-iphone-ipad.md)<br>[Android](./setting-default/firefox-focus-android.md) |
 
 
 ## Kagi App {#kagi_app}

--- a/docs/kagi/getting-started/setting-default/vivaldi-android.md
+++ b/docs/kagi/getting-started/setting-default/vivaldi-android.md
@@ -1,3 +1,4 @@
+> Not your browser/OS? Return to [the hub page](../../../kagi/getting-started/setting-default.md) for setting Kagi as the default search engine.
 # Setting Kagi as Default on Vivaldi (Mobile)
 
 ## Sync Method

--- a/docs/kagi/getting-started/setting-default/vivaldi-ios.md
+++ b/docs/kagi/getting-started/setting-default/vivaldi-ios.md
@@ -1,6 +1,6 @@
 > Not your browser/OS? Return to [the hub page](../../../kagi/getting-started/setting-default.md) for setting Kagi as the default search engine.
 
-# Setting Kagi as the default search engine in Vivaldi
+# Setting Kagi as the default search engine on Vivaldi on iOS
 
 Vivaldi does not currently support adding custom search engines on iOS.
 However, their documentation mentions that it should be possible to add Kagi as a custom engine on their **Desktop** version and then use their sync to add it to the iOS version.


### PR DESCRIPTION
- Included the setting-default.md changes I forgot
- renamed vivaldi-mobile to vivaldi-android in case the two versions end up being different at some point