### PR TITLE
Remove Maps Search tool until it is integrated with Kagi Maps

### DIFF
--- a/docs/kagi/ai/kagi-research.md
+++ b/docs/kagi/ai/kagi-research.md
@@ -23,7 +23,6 @@ Kagi Research Assistants offer two modes: Quick and Research:
 | **Image Editing** |  | ✓ |
 | **Reasoning Model** |  | ✓ |
 | **Wolfram\|Alpha** |  | ✓ |
-| **Maps Search** |  | ✓ |
 
 **Quick** is Kagi's fast agent, designed for quick agentic capabilities. It provides rapid responses with tool usage but prioritizes speed over depth. Choose Kagi Quick when you need quick answers to straightforward tasks.
 


### PR DESCRIPTION
Remove Maps Search tool from Kagi Research page until it is integrated with Kagi Maps