### PR TITLE
Update Vivalid for Android default search engine setup docs

### DIFF
--- a/docs/kagi/getting-started/setting-default/vivaldi-android.md
+++ b/docs/kagi/getting-started/setting-default/vivaldi-android.md
@@ -11,5 +11,5 @@ To set Kagi as the default search engine on Vivaldi for iOS or Android:
 ## Updated Method
 To set Kagi as the default search engine on Vivaldi for Android:
 
-- Head to [kagi.com](https://kagi.com) with a logged in session. Long hold on the search field and pross "Add as Search Engine"
+- Head to [kagi.com](https://kagi.com) with a logged in session. Long hold on the search field and press "Add as Search Engine"
 - Go to settings, navigate to **Search engine** and select "Kagi.com" under Standard Tab.


### PR DESCRIPTION
New updated method available since Android 7.7 as announced here https://vivaldi.com/blog/vivaldi-on-mobile-7-7/

This simplifies the setup method.