### PR TITLE
Fix link to Orion+

### DIFF
--- a/docs/orion/misc/stats.md
+++ b/docs/orion/misc/stats.md
@@ -1,6 +1,6 @@
 # Live stats
 
-Orion is a zero telemetry browser and we do not know the actual number of users using it. So the next best number we can track is the number of users [paying for Orion](https://kagi.com/orion/orionplus.html).
+Orion is a zero telemetry browser and we do not know the actual number of users using it. So the next best number we can track is the number of users [paying for Orion](kagi.com/onboarding?p=orion_plan).
 
 We have a very simple visualisation of Orion+ member count at [kagi.com/stats](https://kagi.com/stats?stat=orion).
 


### PR DESCRIPTION
The current link 404s. I'm not sure if this is the correct replacement or not.