### PR TITLE
Document Kagi's OpenSearch description file

### DIFF
--- a/docs/kagi/getting-started/application-integrations.md
+++ b/docs/kagi/getting-started/application-integrations.md
@@ -1,6 +1,6 @@
 # Integrating Kagi with Other Applications
 
-Kagi can be integrated with other applications to make it easy to quickly search the web from within those applications.
+Kagi can be integrated with other applications to make it easy to quickly search the web from within those applications. If the application supports an [OpenSearch](https://github.com/dewitt/opensearch) description file, use https://kagi.com/opensearch.xml.
 
 ## BoltAI
 


### PR DESCRIPTION
Added OpenSearch integration information for Kagi. I was able to find it through https://kagifeedback.org/d/250-put-httpskagicomopensearchxmls-information-in-httpskagicomassets, but think it should be in our docs.