### PR TITLE
LLM plan types adjustments, general Orion docs improvements

### DIFF
--- a/docs/kagi/ai/assistant.md
+++ b/docs/kagi/ai/assistant.md
@@ -182,8 +182,8 @@ The following keyboard shortcuts are available in Assistant on Mac and PC.
 | Anthropic     | [Claude 4.6 Sonnet (Reasoning)](https://kagi.com/assistant?profile=claude-4-sonnet-thinking)      | claude-4-sonnet-thinking | Ultimate |
 | Anthropic     | [Claude 4.7 Opus (Reasoning)](https://kagi.com/assistant?profile=claude-4-7-opus-thinking)        | claude-4-7-opus-thinking | Ultimate |
 | Anthropic     | [Claude 4.5 Haiku (Reasoning)](https://kagi.com/assistant?profile=claude-4-haiku-thinking)        | claude-4-haiku-thinking  | Ultimate |
-| Deepseek      | [DeepSeek V4 Pro](https://kagi.com/assistant?profile=deepseek-v4-pro)                             | deepseek-v4-pro          | Ultimate |
-| Deepseek      | [DeepSeek V4 Flash](https://kagi.com/assistant?profile=deepseek-v4-flash)                         | deepseek-v4-flash        | All      |
+| DeepSeek      | [DeepSeek V4 Pro](https://kagi.com/assistant?profile=deepseek-v4-pro)                             | deepseek-v4-pro          | Ultimate |
+| DeepSeek      | [DeepSeek V4 Flash](https://kagi.com/assistant?profile=deepseek-v4-flash)                         | deepseek-v4-flash        | All      |
 | Google        | [Gemini 3 Flash (preview)](https://kagi.com/assistant?profile=gemini-3-flash)                     | gemini-3-flash           | All      |
 | Google        | [Gemini 3 Flash (reasoning) (preview)](https://kagi.com/assistant?profile=gemini-3-flash-thinking) | gemini-3-flash-thinking  | All      |
 | Google        | [Gemini 2.5 Flash](https://kagi.com/assistant?profile=gemini-2-5-flash)                           | gemini-2-5-flash         | All      |
@@ -213,8 +213,8 @@ The following keyboard shortcuts are available in Assistant on Mac and PC.
 | xAI           | [Grok 4.1 Fast](https://kagi.com/assistant?profile=grok-4-fast)                                   | grok-4-fast              | All      |
 | xAI           | [Grok 4.1 Fast (Reasoning)](https://kagi.com/assistant?profile=grok-4-fast-thinking)              | grok-4-fast-thinking     | All      |
 | xAI           | [Grok 4](https://kagi.com/assistant?profile=grok-4)                                               | grok-4                   | Ultimate |
-| Z.ai          | [GLM-5.1](https://kagi.com/assistant?profile=glm-5-1)                                             | glm-5-1                  | All      |
-| Z.ai          | [GLM-5.1 (reasoning)](https://kagi.com/assistant?profile=glm-5-1-thinking)                        | glm-5-1-thinking         | All      |
+| Z.ai          | [GLM-5.1](https://kagi.com/assistant?profile=glm-5-1)                                             | glm-5-1                  | Ultimate |
+| Z.ai          | [GLM-5.1 (reasoning)](https://kagi.com/assistant?profile=glm-5-1-thinking)                        | glm-5-1-thinking         | Ultimate |
 | Z.ai          | [GLM-4.7](https://kagi.com/assistant?profile=glm-4-7)                                             | glm-4-7                  | All      |
 | Z.ai          | [GLM-4.7 (reasoning)](https://kagi.com/assistant?profile=glm-4-7-thinking)                        | glm-4-7-thinking         | All      |
 

--- a/docs/orion/orion-plus/orion-plus.md
+++ b/docs/orion/orion-plus/orion-plus.md
@@ -9,14 +9,14 @@ For a small cost ($5 per month, $50 per year, or $150 for lifetime), you’ll ge
 - Access to Release Candidates with bleeding-edge WebKit (faster than stable) and experimental features
 - An Orion+ badge <img src="./media/rocket.svg" alt="Rocket icon" style="display:inline;vertical-align:middle;" /> on the [feedback forum](https://orionfeedback.org) to show your support
 - The Orion+ role in the [Kagi Community Discord](https://kagi.com/discord), giving you access to the release candidate (macOS) and TestFlight (iOS) channels
-- Higher influence in the browser’s development
+- Greater influence in the browser’s development
 - Exclusive Orion+ app icons
 - The satisfaction of supporting an independent, ad-free, zero-telemetry browser
 
-We plan to add more benefits in the near future, check back soon for updates!
+We plan to add more benefits in the near future; check back soon for updates!
 
 ::: info You can subscribe to Orion+ for all platforms [here](https://kagi.com/onboarding?p=orion_plan).
 *Keep in mind that Orion+ does not include access to Kagi Search.*
 
-You can also help by spreading the word about Orion, from social medias to the dinner table.
+You can also help by spreading the word about Orion, from social media to the dinner table.
 :::

--- a/docs/orion/support-and-community/troubleshooting/bug-reporting.md
+++ b/docs/orion/support-and-community/troubleshooting/bug-reporting.md
@@ -1,3 +1,8 @@
+Thank you for helping improve Orion by reporting bugs.
+All bug reports should be posted on [the feedback forum](https://orionfeedback.org), where they can be properly tracked and subsequently fixed.
+
+Please read on to learn how to create a successful and helpful bug report.
+
 # Reporting a Bug
 
 When reporting a bug, it is important to give us as much information as
@@ -6,7 +11,7 @@ very complex pieces of software—every detail matters!
 
 Whenever you open a bug report, you will be given a template that you can
 fill out that will help you write your report. Here is a breakdown of what is
-included, and how it helps us!
+included and how it helps us!
 
 ## Describe Your Issue
 
@@ -14,18 +19,18 @@ included, and how it helps us!
 for any bug report. Please include a clear list of instructions to reproduce the issue, even if you think it may be obvious.
 If we cannot reproduce the problem, we are not able to fix it.
 
-**Important note**: Most likely cause of problems on web pages is Content blocking
-and Web extension. You can rule out both quickly by enabling [Compatibility mode](./troubleshooting-webpage-issues.md#orion-compatibility-mode).
+**Important note**: The most likely causes of problems on web pages are content blocking
+and web extensions. You can rule out both quickly by enabling [Compatibility mode](./troubleshooting-webpage-issues.md#orion-compatibility-mode).
 
 The second most likely cause of issues is WebKit, Orion's rendering engine.
-This is why we will ask you to check if the same problems exists in Safari
-browser. If it does, it is most likely caused by WebKit and this can be more
+This is why we will ask you to check if the same problems exist in the Safari
+browser. If they do, they are most likely caused by WebKit, and this can be more
 difficult for us to fix. In this case, you are encouraged to [submit a bug
 report to WebKit](https://webkit.org/reporting-bugs/).
 
 **Important note**: You can also check if the issue is present using
 [Safari Technology Preview](https://developer.apple.com/safari/technology-preview/)
-if this available and applicable to you.
+if this is available and applicable to you.
 
 2. **Expected behavior**. What did you expect would happen? Indicating how
 other browsers behave may be useful. Use a screenshot/video to make your
@@ -36,7 +41,7 @@ point if needed.
 ## Give Us Some Context
 
 1. **Orion and OS version; hardware type**. What is the version of Orion, your
-system and what hardware you are running. You can copy this from Orion ->
+system, and what hardware you are running? You can copy this from Orion ->
 About menu if unsure. There is a lot of debug information available in Help
 -> Copy Debug Info to Clipboard that can be useful to us.
 
@@ -44,7 +49,7 @@ About menu if unsure. There is a lot of debug information available in Help
 2. **Image/Video**. It is always helpful to upload images/videos. Our site will allow dragging and dropping files as you write.
 
 
-3. **Provide process logs**. If you are experiencing glitches, freezes or beachballs, you can include process logs from within Activity Monitor. Select the main Orion process (look for the Orion icon) from the list and under View, select Sample Process. You can save that analysis as a text file and attach it to your report.
+3. **Provide process logs**. If you are experiencing glitches, freezes, or beachballs, you can include process logs from within Activity Monitor. Select the main Orion process (look for the Orion icon) from the list and, under View, select Sample Process. You can save that analysis as a text file and attach it to your report.
 
 ## Things to Try
 


### PR DESCRIPTION
- GLM5.1 is Ultimate-only, and this is now correctly reflected in the documentation
- added a link to the feedback forum at the top of the Orion bug-reporting instruction page
- made minor language fixes on the bug-reporting and Orion+ pages