### PR TITLE
Document Pixel Launcher search widget workaround

### DIFF
--- a/docs/kagi/getting-started/setting-default.md
+++ b/docs/kagi/getting-started/setting-default.md
@@ -32,6 +32,30 @@ The Kagi app is currently available for Android. Download it from the [Google Pl
 - Use the app directly to search with Kagi on your device.
 - Privacy Pass is supported in the Android app. For setup instructions, see the [Getting Started with Privacy Pass](../privacy/privacy-pass.html#getting-started) page.
 
+#### Pixel Launcher (Advanced)
+
+If you are using the Pixel Launcher, you can replace the default Google Search widget with the Kagi Search widget, even though Kagi is not currently offered in Google's list of supported search providers.
+
+> **Note**<br />This method is intended for advanced users. It requires enabling **Developer Options** and **USB debugging**, and using Android Debug Bridge (ADB).
+
+1. Install the Kagi app.
+2. Connect your device to a computer with ADB installed.
+3. Run:
+
+```bash
+adb shell settings put secure selected_search_engine com.kagi.search
+```
+
+The default Google Search widget will be replaced with the Kagi Search widget.
+
+To restore the default Google Search widget, choose **Google** as the default search engine in the Pixel Launcher settings. Alternatively, you can run:
+
+```bash
+adb shell settings put secure selected_search_engine com.google.android.googlequicksearchbox
+```
+
+> **Note**<br />This workaround relies on an undocumented Android system setting and may stop working in future Android releases.
+
 ### iPhone
 
 An iOS app is not yet available. Once released, it will include support for homescreen widgets and direct search. Updates will be posted here when the app is available.


### PR DESCRIPTION
# Products Updated

- [x] Kagi Search Docs
- [ ] Kagi Developer Docs

## Description

Add documentation for an advanced Android workaround that allows the Pixel Launcher search widget to use the Kagi app.

The workaround uses an undocumented Android system setting and is clearly marked as an advanced option requiring Developer Options, USB debugging, and ADB. The documentation also includes instructions for restoring the default Google Search widget.

| Before | After |
|--------|-------|
| <img width="1028" height="541" alt="before" src="https://github.com/user-attachments/assets/8e276992-dc57-4882-9df9-6b5a53b92058" /> | <img width="1028" height="541" alt="after" src="https://github.com/user-attachments/assets/8cf53dd6-078d-4dc4-97aa-c5b014c86e05" /> |