### PR TITLE
fix(build): install from lockfile and pin markdown-it-image-size

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -13,9 +13,9 @@ jobs:
   buildtest:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3.5.3
-    - uses: docker/setup-buildx-action@v2
-    - uses: docker/build-push-action@v4
+    - uses: actions/checkout@v7.0.1
+    - uses: docker/setup-buildx-action@v4
+    - uses: docker/build-push-action@v7
       with:
         tags: "test-kagi-docs:latest"
         push: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,4 @@ RUN npm ci
 COPY . .
 
 RUN npm run docs:build
-ENTRYPOINT npm run docs:preview
+ENTRYPOINT ["npm", "run", "docs:preview"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-ARG NODE_VERSION=19
+ARG NODE_VERSION=22
 FROM node:${NODE_VERSION}-alpine
 
 WORKDIR /usr/src/app
 
-COPY package.json .
-RUN npm install
+COPY package.json package-lock.json .
+RUN npm ci
 
 COPY . .
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,8 +1,8 @@
 steps:
-  - name: 'node:19'
+  - name: 'node:22'
     entrypoint: 'npm'
-    args: ['install']
-  - name: 'node:19'
+    args: ['ci']
+  - name: 'node:22'
     entrypoint: 'npm'
     args:
       - 'run'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "kagi-docs",
+  "name": "app",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -9,7 +9,7 @@
         "@vscode/markdown-it-katex": "^1.1.1",
         "esbuild": "^0.25.0",
         "kagi-sidekick-vitepress": "^0.0.1-alpha.22",
-        "markdown-it-image-size": "^15.1.0",
+        "markdown-it-image-size": "15.1.0",
         "medium-zoom": "^1.1.0",
         "sortable-tablesort": "^4.0.1",
         "vitepress": "^1.6.3",
@@ -877,6 +877,7 @@
       "version": "2.5.6",
       "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
       "integrity": "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -916,6 +917,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -936,6 +938,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -956,6 +959,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -976,6 +980,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -996,9 +1001,7 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1019,9 +1022,7 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "musl"
-      ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1042,9 +1043,7 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1065,9 +1064,7 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1088,9 +1085,7 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1111,9 +1106,7 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1134,6 +1127,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1154,6 +1148,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1174,6 +1169,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2050,6 +2046,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "engines": {
@@ -2366,6 +2363,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -2376,6 +2374,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -2742,6 +2741,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -2835,6 +2835,7 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -3982,6 +3983,21 @@
         "universal-cookie": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vitepress/node_modules/fuse.js": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.5.0.tgz",
+      "integrity": "sha512-sQtrEfA+ez/3G0cCZecF70oqpCRttCexYUG4mUrtWL49ULUzUyxokt5kyqwtKzj1270RaKih+hcP3qLcumccow==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/krisk"
       }
     },
     "node_modules/vue": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "app",
+  "name": "kagi-docs",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@vscode/markdown-it-katex": "^1.1.1",
     "esbuild": "^0.25.0",
     "kagi-sidekick-vitepress": "^0.0.1-alpha.22",
-    "markdown-it-image-size": "^15.1.0",
+    "markdown-it-image-size": "15.1.0",
     "medium-zoom": "^1.1.0",
     "sortable-tablesort": "^4.0.1",
     "vitepress": "^1.6.3",


### PR DESCRIPTION
# Products Updated

Check all that apply:

- [ ] Kagi Search Docs
- [ ] Kagi Developer Docs

_No documentation content changes — this is build tooling only. It does, however, unblock the build and deploy pipeline for the Kagi Search Docs site (help.kagi.com)._

## Description

Fixes INFRA-1807

The docs build started failing with `Cannot find module 'sync-fetch'` while loading `docs/.vitepress/config.ts`. No config file was touched — an upstream package published a broken release and our build was set up to pick it up automatically.

`markdown-it-image-size@15.3.0` dropped `sync-fetch` from its `dependencies` while its shipped `dist/index.js` still requires it:

```
15.1.0 deps: flat-cache, image-size, sync-fetch, @types/markdown-it
15.3.0 deps: flat-cache, image-size, @types/markdown-it      <- sync-fetch dropped
```

Both build paths ran `npm install` against `package.json` alone, never copying the committed lockfile, so the `^15.1.0` range silently resolved to the broken 15.3.0 on every fresh build. The same commit built fine one day and failed the next.

### Changes

- **`Dockerfile`** and **`cloudbuild.yaml`** — copy `package-lock.json` and use `npm ci`, so builds install the exact tested tree. `cloudbuild.yaml` is the production deploy to help.kagi.com and had the identical bug, so it is fixed too.
- **`package.json`** — pin `markdown-it-image-size` to exactly `15.1.0` so `npm update` cannot pull the broken release back in.
- **`package-lock.json`** — regenerated. The committed lockfile was missing vitepress' optional peer `fuse.js` and so was rejected by `npm ci` as-is (`EUSAGE ... Missing: fuse.js@7.5.0 from lock file`).
- **Node 19 -> 22** in both paths; `markdown-it-image-size` declares `engines: node >= 20`.
- **`.github/workflows/pr.yml`** — bump `actions/checkout` to v7.0.1, `docker/setup-buildx-action` to v4, `docker/build-push-action` to v7.

### Verification

Full `docker build` run locally and green on both build environments:

- `node:22-alpine` at `/usr/src/app` — the Dockerfile / CI path
- glibc `node:22` at `/workspace` — the cloudbuild path

Both matter because the lockfile regeneration changed `libc` constraints on the rollup binaries, and the two paths use different C libraries. All three GitHub Action tags were confirmed to resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)